### PR TITLE
트랙 관련 기능 구현: 생성, 조회, 참가자 추가 및 조회

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/AuthService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/AuthService.java
@@ -1,15 +1,17 @@
 package wercsmik.spaghetticodingclub.domain.auth.service;
 
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import wercsmik.spaghetticodingclub.domain.auth.dto.SignRequestDTO;
+import wercsmik.spaghetticodingclub.domain.track.service.TrackParticipantsService;
 import wercsmik.spaghetticodingclub.domain.user.entity.User;
 import wercsmik.spaghetticodingclub.domain.user.entity.UserRoleEnum;
 import wercsmik.spaghetticodingclub.domain.user.repository.UserRepository;
 import wercsmik.spaghetticodingclub.global.exception.CustomException;
 import wercsmik.spaghetticodingclub.global.exception.ErrorCode;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +19,7 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final TrackParticipantsService trackParticipantsService;
 
     public void signup(SignRequestDTO signRequestDTO) {
 
@@ -41,7 +44,7 @@ public class AuthService {
 
         UserRoleEnum role = UserRoleEnum.USER; // 기본적으로 USER로 설정
         // recommendEmail 값이 null이 아니고 빈 문자열이 아닐 경우에만 ADMIN 설정
-        if(recommendEmail != null && !recommendEmail.trim().isEmpty()) {
+        if (recommendEmail != null && !recommendEmail.trim().isEmpty()) {
             role = UserRoleEnum.ADMIN;
         }
 
@@ -54,5 +57,8 @@ public class AuthService {
                 .role(role)
                 .build();
         userRepository.save(user);
+
+        // 사용자를 트랙참여자에 추가
+        trackParticipantsService.addParticipant(user.getId(), user.getTrack());
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackController.java
@@ -1,4 +1,29 @@
 package wercsmik.spaghetticodingclub.domain.track.controller;
 
-public class TrackController {
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.service.TrackService;
+import wercsmik.spaghetticodingclub.global.auditing.BaseTimeEntity;
+import wercsmik.spaghetticodingclub.global.common.CommonResponse;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/tracks")
+public class TrackController extends BaseTimeEntity {
+
+    private final TrackService trackService;
+
+    @GetMapping
+    public ResponseEntity<CommonResponse<List<TrackResponseDTO>>> getAllTracks() {
+
+        List<TrackResponseDTO> tracks = trackService.getAllTracks();
+
+        return ResponseEntity.ok().body(CommonResponse.of("트랙 전체 조회 성공", tracks));
+    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackController.java
@@ -2,9 +2,9 @@ package wercsmik.spaghetticodingclub.domain.track.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackRequestDTO;
 import wercsmik.spaghetticodingclub.domain.track.dto.TrackResponseDTO;
 import wercsmik.spaghetticodingclub.domain.track.service.TrackService;
 import wercsmik.spaghetticodingclub.global.auditing.BaseTimeEntity;
@@ -18,6 +18,16 @@ import java.util.List;
 public class TrackController extends BaseTimeEntity {
 
     private final TrackService trackService;
+
+    @PostMapping
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    public ResponseEntity<CommonResponse<TrackResponseDTO>> createTrack(
+            @RequestBody TrackRequestDTO trackRequestDTO) {
+
+        TrackResponseDTO createdTrack = trackService.createTrack(trackRequestDTO);
+
+        return ResponseEntity.ok().body(CommonResponse.of("트랙 생성 성공", createdTrack));
+    }
 
     @GetMapping
     public ResponseEntity<CommonResponse<List<TrackResponseDTO>>> getAllTracks() {

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackParticipantsController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackParticipantsController.java
@@ -1,0 +1,33 @@
+package wercsmik.spaghetticodingclub.domain.track.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackParticipantResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.service.TrackParticipantsService;
+import wercsmik.spaghetticodingclub.global.common.CommonResponse;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+//@PreAuthorize("hasRole('ADMIN')")
+@RequestMapping("/trackParticipants")
+public class TrackParticipantsController {
+
+    private final TrackParticipantsService trackParticipantsService;
+
+    @GetMapping("/{trackId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<CommonResponse<List<TrackParticipantResponseDTO>>> getParticipantsByTrackId(
+            @PathVariable Long trackId) {
+
+        List<TrackParticipantResponseDTO> participants = trackParticipantsService.getParticipantsByTrack(trackId);
+
+        return ResponseEntity.ok().body(CommonResponse.of("트랙 참가자 조회 성공", participants));
+    }
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackParticipantResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackParticipantResponseDTO.java
@@ -1,0 +1,19 @@
+package wercsmik.spaghetticodingclub.domain.track.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class TrackParticipantResponseDTO {
+
+    private Long userId;
+
+    private String userName;
+
+    private Long trackId;
+
+    private LocalDateTime joinedAt;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackParticipantResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackParticipantResponseDTO.java
@@ -15,5 +15,7 @@ public class TrackParticipantResponseDTO {
 
     private Long trackId;
 
+    private String trackName;
+
     private LocalDateTime joinedAt;
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackRequestDTO.java
@@ -1,4 +1,11 @@
 package wercsmik.spaghetticodingclub.domain.track.dto;
 
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
 public class TrackRequestDTO {
+
+    private final String trackName;
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackRequestDTO.java
@@ -1,11 +1,15 @@
 package wercsmik.spaghetticodingclub.domain.track.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class TrackRequestDTO {
 
-    private final String trackName;
+    private String trackName;
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackResponseDTO.java
@@ -1,4 +1,13 @@
 package wercsmik.spaghetticodingclub.domain.track.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
 public class TrackResponseDTO {
+
+    private Long trackId;
+
+    private String trackName;
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/Track.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/Track.java
@@ -12,16 +12,8 @@ public class Track extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long trackId;
 
     @Column(nullable = false, length = 50)
     private String trackName;
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public void setTrackName(String trackName) {
-        this.trackName = trackName;
-    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/Track.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/Track.java
@@ -1,12 +1,16 @@
 package wercsmik.spaghetticodingclub.domain.track.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import wercsmik.spaghetticodingclub.global.auditing.BaseTimeEntity;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @RequiredArgsConstructor
 public class Track extends BaseTimeEntity {
 

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/Track.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/Track.java
@@ -1,4 +1,27 @@
 package wercsmik.spaghetticodingclub.domain.track.entity;
 
-public class Track {
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import wercsmik.spaghetticodingclub.global.auditing.BaseTimeEntity;
+
+@Entity
+@Getter
+@RequiredArgsConstructor
+public class Track extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String trackName;
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public void setTrackName(String trackName) {
+        this.trackName = trackName;
+    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipantId.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipantId.java
@@ -2,19 +2,22 @@ package wercsmik.spaghetticodingclub.domain.track.entity;
 
 import jakarta.persistence.Embeddable;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 import java.util.Objects;
 
 @Embeddable
 @Getter
+@NoArgsConstructor
 public class TrackParticipantId implements Serializable {
 
     private Long userId;
-
     private Long trackId;
 
-    public TrackParticipantId() {
+    public TrackParticipantId(Long userId, Long trackId) {
+        this.userId = userId;
+        this.trackId = trackId;
     }
 
     @Override

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipantId.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipantId.java
@@ -1,0 +1,15 @@
+package wercsmik.spaghetticodingclub.domain.track.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+@Embeddable
+@Getter
+public class TrackParticipantId implements Serializable {
+
+    private Long userId;
+
+    private Long trackId;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipantId.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipantId.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Embeddable;
 import lombok.Getter;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 @Embeddable
 @Getter
@@ -12,4 +13,21 @@ public class TrackParticipantId implements Serializable {
     private Long userId;
 
     private Long trackId;
+
+    public TrackParticipantId() {
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TrackParticipantId)) return false;
+        TrackParticipantId that = (TrackParticipantId) o;
+        return Objects.equals(getUserId(), that.getUserId()) &&
+                Objects.equals(getTrackId(), that.getTrackId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getUserId(), getTrackId());
+    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipants.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipants.java
@@ -1,0 +1,28 @@
+package wercsmik.spaghetticodingclub.domain.track.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import wercsmik.spaghetticodingclub.domain.user.entity.User;
+import wercsmik.spaghetticodingclub.global.auditing.BaseTimeEntity;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@RequiredArgsConstructor
+public class TrackParticipants extends BaseTimeEntity {
+
+    @Id
+    @ManyToOne
+    @JoinColumn(name="userId", nullable = false)
+    private User user;
+
+    @Id
+    @ManyToOne
+    @JoinColumn(name="trackId", nullable = false)
+    private Track track;
+
+    @Column(nullable = false)
+    private LocalDateTime joinedAt;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipants.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipants.java
@@ -17,12 +17,13 @@ public class TrackParticipants {
 
     @MapsId("userId") // TrackParticipantId의 userId 필드를 매핑
     @ManyToOne
+    // TODO: merge 후, referencedColumnName = "userId"로 변경
     @JoinColumn(name = "userId", referencedColumnName = "id")
     private User user;
 
     @MapsId("trackId") // TrackParticipantId의 trackId 필드를 매핑
     @ManyToOne
-    @JoinColumn(name = "trackId", referencedColumnName = "id")
+    @JoinColumn(name = "trackId", referencedColumnName = "trackId")
     private Track track;
 
     @Column(nullable = false)

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipants.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipants.java
@@ -1,6 +1,7 @@
 package wercsmik.spaghetticodingclub.domain.track.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import wercsmik.spaghetticodingclub.domain.user.entity.User;
@@ -9,6 +10,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Builder
 @RequiredArgsConstructor
 public class TrackParticipants {
 
@@ -29,14 +31,22 @@ public class TrackParticipants {
     @Column(nullable = false)
     private LocalDateTime joinedAt;
 
-    public static TrackParticipantsBuilder builder() {
-        return new TrackParticipantsBuilder();
-    }
-
     public static class TrackParticipantsBuilder {
+        private Long userId;
+        private Long trackId;
         private User user;
         private Track track;
         private LocalDateTime joinedAt;
+
+        public TrackParticipantsBuilder userId(Long userId) {
+            this.userId = userId;
+            return this;
+        }
+
+        public TrackParticipantsBuilder trackId(Long trackId) {
+            this.trackId = trackId;
+            return this;
+        }
 
         public TrackParticipantsBuilder user(User user) {
             this.user = user;
@@ -55,6 +65,7 @@ public class TrackParticipants {
 
         public TrackParticipants build() {
             TrackParticipants trackParticipants = new TrackParticipants();
+            trackParticipants.id = new TrackParticipantId(this.userId, this.trackId); // TrackParticipantId 초기화
             trackParticipants.user = this.user;
             trackParticipants.track = this.track;
             trackParticipants.joinedAt = this.joinedAt;

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipants.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipants.java
@@ -4,25 +4,60 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import wercsmik.spaghetticodingclub.domain.user.entity.User;
-import wercsmik.spaghetticodingclub.global.auditing.BaseTimeEntity;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @RequiredArgsConstructor
-public class TrackParticipants extends BaseTimeEntity {
+public class TrackParticipants {
 
-    @Id
+    @EmbeddedId
+    private TrackParticipantId id;
+
+    @MapsId("userId") // TrackParticipantId의 userId 필드를 매핑
     @ManyToOne
-    @JoinColumn(name="userId", nullable = false)
+    @JoinColumn(name = "userId", referencedColumnName = "id")
     private User user;
 
-    @Id
+    @MapsId("trackId") // TrackParticipantId의 trackId 필드를 매핑
     @ManyToOne
-    @JoinColumn(name="trackId", nullable = false)
+    @JoinColumn(name = "trackId", referencedColumnName = "id")
     private Track track;
 
     @Column(nullable = false)
     private LocalDateTime joinedAt;
+
+    public static TrackParticipantsBuilder builder() {
+        return new TrackParticipantsBuilder();
+    }
+
+    public static class TrackParticipantsBuilder {
+        private User user;
+        private Track track;
+        private LocalDateTime joinedAt;
+
+        public TrackParticipantsBuilder user(User user) {
+            this.user = user;
+            return this;
+        }
+
+        public TrackParticipantsBuilder track(Track track) {
+            this.track = track;
+            return this;
+        }
+
+        public TrackParticipantsBuilder joinedAt(LocalDateTime joinedAt) {
+            this.joinedAt = joinedAt;
+            return this;
+        }
+
+        public TrackParticipants build() {
+            TrackParticipants trackParticipants = new TrackParticipants();
+            trackParticipants.user = this.user;
+            trackParticipants.track = this.track;
+            trackParticipants.joinedAt = this.joinedAt;
+            return trackParticipants;
+        }
+    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackParticipantsRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackParticipantsRepository.java
@@ -1,0 +1,12 @@
+package wercsmik.spaghetticodingclub.domain.track.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wercsmik.spaghetticodingclub.domain.track.entity.TrackParticipantId;
+import wercsmik.spaghetticodingclub.domain.track.entity.TrackParticipants;
+
+import java.util.List;
+
+public interface TrackParticipantsRepository extends JpaRepository<TrackParticipants, TrackParticipantId> {
+
+    List<TrackParticipants> findByTrackId(Long trackId);
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackParticipantsRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackParticipantsRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 public interface TrackParticipantsRepository extends JpaRepository<TrackParticipants, TrackParticipantId> {
 
-    List<TrackParticipants> findByTrackId(Long trackId);
+    List<TrackParticipants> findByTrackTrackId(Long trackId);
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackRepository.java
@@ -3,7 +3,11 @@ package wercsmik.spaghetticodingclub.domain.track.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import wercsmik.spaghetticodingclub.domain.track.entity.Track;
 
+import java.util.Optional;
+
 public interface TrackRepository extends JpaRepository<Track, Long> {
 
     boolean existsByTrackName(String trackName);
+
+    Optional<Track> findByTrackName(String trackName);
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackRepository.java
@@ -1,4 +1,7 @@
 package wercsmik.spaghetticodingclub.domain.track.repository;
 
-public interface TrackRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import wercsmik.spaghetticodingclub.domain.track.entity.Track;
+
+public interface TrackRepository extends JpaRepository<Track, Long> {
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackRepository.java
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import wercsmik.spaghetticodingclub.domain.track.entity.Track;
 
 public interface TrackRepository extends JpaRepository<Track, Long> {
+
+    boolean existsByTrackName(String trackName);
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
@@ -1,6 +1,5 @@
 package wercsmik.spaghetticodingclub.domain.track.service;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import wercsmik.spaghetticodingclub.domain.track.dto.TrackParticipantResponseDTO;
@@ -13,6 +12,7 @@ import wercsmik.spaghetticodingclub.domain.user.repository.UserRepository;
 import wercsmik.spaghetticodingclub.global.exception.CustomException;
 import wercsmik.spaghetticodingclub.global.exception.ErrorCode;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,6 +37,7 @@ public class TrackParticipantsService {
         TrackParticipants participant = TrackParticipants.builder()
                 .user(user)
                 .track(track)
+                .joinedAt(LocalDateTime.now())
                 .build();
 
         trackParticipantsRepository.save(participant);
@@ -51,6 +52,7 @@ public class TrackParticipantsService {
                         participant.getUser().getId(),
                         participant.getUser().getUsername(),
                         participant.getTrack().getTrackId(),
+                        participant.getTrack().getTrackName(),
                         participant.getJoinedAt()))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
@@ -1,10 +1,17 @@
 package wercsmik.spaghetticodingclub.domain.track.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import wercsmik.spaghetticodingclub.domain.track.dto.TrackParticipantResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.entity.Track;
 import wercsmik.spaghetticodingclub.domain.track.entity.TrackParticipants;
 import wercsmik.spaghetticodingclub.domain.track.repository.TrackParticipantsRepository;
+import wercsmik.spaghetticodingclub.domain.track.repository.TrackRepository;
+import wercsmik.spaghetticodingclub.domain.user.entity.User;
+import wercsmik.spaghetticodingclub.domain.user.repository.UserRepository;
+import wercsmik.spaghetticodingclub.global.exception.CustomException;
+import wercsmik.spaghetticodingclub.global.exception.ErrorCode;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,6 +21,26 @@ import java.util.stream.Collectors;
 public class TrackParticipantsService {
 
     private final TrackParticipantsRepository trackParticipantsRepository;
+
+    private final UserRepository userRepository;
+
+    private final TrackRepository trackRepository;
+
+    public void addParticipant(Long userId, String trackName) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Track track = trackRepository.findByTrackName(trackName)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOT_FOUND));
+
+        TrackParticipants participant = TrackParticipants.builder()
+                .user(user)
+                .track(track)
+                .build();
+
+        trackParticipantsRepository.save(participant);
+    }
 
     public List<TrackParticipantResponseDTO> getParticipantsByTrack(Long trackId) {
 

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
@@ -16,7 +16,9 @@ public class TrackParticipantsService {
     private final TrackParticipantsRepository trackParticipantsRepository;
 
     public List<TrackParticipantResponseDTO> getParticipantsByTrack(Long trackId) {
-        List<TrackParticipants> participants = trackParticipantsRepository.findByTrackId(trackId);
+
+        List<TrackParticipants> participants = trackParticipantsRepository.findByTrackTrackId(trackId);
+
         return participants.stream()
                 .map(participant -> new TrackParticipantResponseDTO(
                         participant.getUser().getId(),

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
@@ -1,0 +1,28 @@
+package wercsmik.spaghetticodingclub.domain.track.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackParticipantResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.entity.TrackParticipants;
+import wercsmik.spaghetticodingclub.domain.track.repository.TrackParticipantsRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TrackParticipantsService {
+
+    private final TrackParticipantsRepository trackParticipantsRepository;
+
+    public List<TrackParticipantResponseDTO> getParticipantsByTrack(Long trackId) {
+        List<TrackParticipants> participants = trackParticipantsRepository.findByTrackId(trackId);
+        return participants.stream()
+                .map(participant -> new TrackParticipantResponseDTO(
+                        participant.getUser().getId(),
+                        participant.getUser().getUsername(),
+                        participant.getTrack().getId(),
+                        participant.getJoinedAt()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
@@ -21,7 +21,7 @@ public class TrackParticipantsService {
                 .map(participant -> new TrackParticipantResponseDTO(
                         participant.getUser().getId(),
                         participant.getUser().getUsername(),
-                        participant.getTrack().getId(),
+                        participant.getTrack().getTrackId(),
                         participant.getJoinedAt()))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackService.java
@@ -28,7 +28,7 @@ public class TrackService {
                 .getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"));
 
         if (!isAdmin) {
-            throw new CustomException(ErrorCode.NOT_ADMIN);
+            throw new CustomException(ErrorCode.NO_AUTHENTICATION);
         }
 
         if (trackRequestDTO.getTrackName() == null || trackRequestDTO.getTrackName().isEmpty()) {

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackService.java
@@ -1,10 +1,16 @@
 package wercsmik.spaghetticodingclub.domain.track.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackRequestDTO;
 import wercsmik.spaghetticodingclub.domain.track.dto.TrackResponseDTO;
 import wercsmik.spaghetticodingclub.domain.track.entity.Track;
 import wercsmik.spaghetticodingclub.domain.track.repository.TrackRepository;
+import wercsmik.spaghetticodingclub.global.exception.CustomException;
+import wercsmik.spaghetticodingclub.global.exception.ErrorCode;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,6 +20,33 @@ import java.util.stream.Collectors;
 public class TrackService {
 
     private final TrackRepository trackRepository;
+
+    @Transactional
+    public TrackResponseDTO createTrack(TrackRequestDTO trackRequestDTO) {
+
+        boolean isAdmin = SecurityContextHolder.getContext().getAuthentication()
+                .getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"));
+
+        if (!isAdmin) {
+            throw new CustomException(ErrorCode.NOT_ADMIN);
+        }
+
+        if (trackRequestDTO.getTrackName() == null || trackRequestDTO.getTrackName().isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_TRACK_NAME);
+        }
+
+        if (trackRepository.existsByTrackName(trackRequestDTO.getTrackName())) {
+            throw new CustomException(ErrorCode.TRACK_NAME_DUPLICATED);
+        }
+
+        Track track = Track.builder()
+                .trackName(trackRequestDTO.getTrackName())
+                .build();
+
+        Track savedTrack = trackRepository.save(track);
+
+        return new TrackResponseDTO(savedTrack.getTrackId(), savedTrack.getTrackName());
+    }
 
     public List<TrackResponseDTO> getAllTracks() {
 

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackService.java
@@ -1,4 +1,26 @@
 package wercsmik.spaghetticodingclub.domain.track.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.entity.Track;
+import wercsmik.spaghetticodingclub.domain.track.repository.TrackRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
 public class TrackService {
+
+    private final TrackRepository trackRepository;
+
+    public List<TrackResponseDTO> getAllTracks() {
+
+        List<Track> tracks = trackRepository.findAll();
+
+        return tracks.stream()
+                .map(track -> new TrackResponseDTO(track.getTrackId(), track.getTrackName()))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/global/auditing/BaseTimeEntity.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/auditing/BaseTimeEntity.java
@@ -1,4 +1,24 @@
 package wercsmik.spaghetticodingclub.global.auditing;
 
-public class BaseTimeEntity {
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/global/auditing/JpaAuditingConfiguration.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/auditing/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package wercsmik.spaghetticodingclub.global.auditing;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/global/config/WebSecurityConfig.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/config/WebSecurityConfig.java
@@ -66,6 +66,7 @@ public class WebSecurityConfig {
                 authorizeHttpRequests
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
                         .requestMatchers("/api/auths/**").permitAll() // '/api/auths/'로 시작하는 요청 모두 접근 허가
+                        .requestMatchers("/tracks").permitAll() // '/tracks' 요청 접근 허가 (트랙 전체 조회)
                         .requestMatchers("/spaghettiiii").permitAll() // aws 테스트를 위함
                         .requestMatchers("/").permitAll() // 메인 페이지 요청 허가
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리

--- a/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
@@ -49,11 +49,10 @@ public enum ErrorCode {
 
     UNSUPPORTED_JWT_TOKEN(401, "지원되지 않는 JWT 토큰 입니다."),
 
-    INVALID_JWT_TOKEN(401, "잘못된 JWT 토큰 입니다."),
+    INVALID_JWT_TOKEN(401, "잘못된 JWT 토큰 입니다.");
 
 
     // User
-    NOT_ADMIN(401, "관리자 권한이 필요합니다.");
 
 
     // Common

--- a/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 
-    // Assesment
+    // Assessment
+
 
     // Auth
     PASSWORD_NOT_MATCH(401, "비밀번호가 일치하지 않습니다."),
@@ -24,25 +25,35 @@ public enum ErrorCode {
 
     // Scheduler
 
+
     // Team
+
 
     // Track
     USER_ALREADY_PARTICIPANT(400, "이미 트랙 참여자입니다."),
 
     TRACK_NOT_FOUND(400, "트랙을 찾을 수 없습니다."),
 
+    TRACK_NAME_DUPLICATED(400, "이미 존재하는 트랙입니다."),
+
+    INVALID_TRACK_NAME(400, "잘못된 트랙 이름입니다."),
+
+
     // Unlike
 
-    //Jwt
+
+    // Jwt
     INVALID_JWT_SIGNATURE(401, "유효하지 않는 JWT 서명 입니다."),
 
     EXPIRED_JWT_TOKEN(401, "만료된 JWT Token 입니다."),
 
     UNSUPPORTED_JWT_TOKEN(401, "지원되지 않는 JWT 토큰 입니다."),
 
-    INVALID_JWT_TOKEN(401, "잘못된 JWT 토큰 입니다.");
+    INVALID_JWT_TOKEN(401, "잘못된 JWT 토큰 입니다."),
+
 
     // User
+    NOT_ADMIN(401, "관리자 권한이 필요합니다.");
 
 
     // Common

--- a/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
@@ -27,6 +27,9 @@ public enum ErrorCode {
     // Team
 
     // Track
+    USER_ALREADY_PARTICIPANT(400, "이미 트랙 참여자입니다."),
+
+    TRACK_NOT_FOUND(400, "트랙을 찾을 수 없습니다."),
 
     // Unlike
 


### PR DESCRIPTION
## 변경 사항 요약
- 트랙 생성, 조회, 참가자 추가 및 조회 기능을 구현하였습니다. 이는 사용자와 관리자 모두에게 트랙 관련 정보를 효율적으로 관리할 수 있는 기능을 제공합니다.

## 상세 변경 내용
1. **트랙 생성 기능과 API**
   - 관리자만 트랙을 생성할 수 있는 기능을 구현하였습니다. 트랙명은 고유해야 하며, 중복된 트랙명으로 생성 시도 시 오류를 반환합니다.

2. **트랙 조회 기능과 API**
   - 모든 사용자가 등록된 트랙 목록을 조회할 수 있는 기능을 구현하였습니다. 이를 통해 사용자는 다양한 트랙 정보를 쉽게 접근할 수 있습니다.

3. **트랙 참가자 추가 기능**
   - 사용자가 특정 트랙의 참가자로 추가될 수 있는 기능을 구현하였습니다. 참가자 추가 시 현재 시간이 참가 시점으로 기록됩니다.

4. **트랙 참가자 조회 기능과 API**
   - 특정 트랙의 모든 참가자를 조회할 수 있는 기능을 구현하였습니다. 이를 통해 사용자는 트랙별 참가자 정보를 쉽게 확인할 수 있습니다.

## 테스트 결과
- Postman을 통한 테스트를 통해 각 기능의 정상 작동을 확인하였고 테스트를 통해 기능의 안정성을 검증하였습니다.

## 기대 효과
- 트랙 관련 기능의 구현을 통해 사용자와 관리자는 트랙 정보를 효율적으로 관리할 수 있게 되었습니다.