### PR TITLE
feat: 트랙 참여자의 트랙 수정

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackParticipantsController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackParticipantsController.java
@@ -3,11 +3,10 @@ package wercsmik.spaghetticodingclub.domain.track.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import wercsmik.spaghetticodingclub.domain.track.dto.TrackParticipantResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackParticipantUpdateResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackUpdateRequestDTO;
 import wercsmik.spaghetticodingclub.domain.track.service.TrackParticipantsService;
 import wercsmik.spaghetticodingclub.global.common.CommonResponse;
 
@@ -15,7 +14,6 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-//@PreAuthorize("hasRole('ADMIN')")
 @RequestMapping("/trackParticipants")
 public class TrackParticipantsController {
 
@@ -28,6 +26,19 @@ public class TrackParticipantsController {
 
         List<TrackParticipantResponseDTO> participants = trackParticipantsService.getParticipantsByTrack(trackId);
 
-        return ResponseEntity.ok().body(CommonResponse.of("트랙 참가자 조회 성공", participants));
+        return ResponseEntity.ok().body(CommonResponse.of("트랙 참여자 조회 성공", participants));
+    }
+
+    @PutMapping("/{userId}/{oldTrackId}")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    public ResponseEntity<CommonResponse<TrackParticipantUpdateResponseDTO>> updateParticipantTrack(
+            @PathVariable Long userId,
+            @PathVariable Long oldTrackId,
+            @RequestBody TrackUpdateRequestDTO trackUpdateRequest) {
+
+        TrackParticipantUpdateResponseDTO updatedInfo = trackParticipantsService.updateParticipantTrack(
+                userId, oldTrackId, trackUpdateRequest.getNewTrackName());
+
+        return ResponseEntity.ok().body(CommonResponse.of("트랙 참가자의 트랙 수정 성공", updatedInfo));
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackParticipantUpdateResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackParticipantUpdateResponseDTO.java
@@ -1,0 +1,17 @@
+package wercsmik.spaghetticodingclub.domain.track.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TrackParticipantUpdateResponseDTO {
+
+    private Long userId;
+
+    private String updatedTrackName;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackUpdateRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackUpdateRequestDTO.java
@@ -1,0 +1,15 @@
+package wercsmik.spaghetticodingclub.domain.track.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TrackUpdateRequestDTO {
+
+    private String newTrackName;
+
+    public TrackUpdateRequestDTO(String newTrackName) {
+        this.newTrackName = newTrackName;
+    }
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipants.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipants.java
@@ -30,6 +30,10 @@ public class TrackParticipants {
     @Column(nullable = false)
     private LocalDateTime joinedAt;
 
+    public void updateTrack(Track newTrack) {
+        this.track = newTrack;
+    }
+
     public static class TrackParticipantsBuilder {
         private Long userId;
         private Long trackId;

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
@@ -1,9 +1,15 @@
 package wercsmik.spaghetticodingclub.domain.track.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import wercsmik.spaghetticodingclub.domain.track.dto.TrackParticipantResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackParticipantUpdateResponseDTO;
 import wercsmik.spaghetticodingclub.domain.track.entity.Track;
+import wercsmik.spaghetticodingclub.domain.track.entity.TrackParticipantId;
 import wercsmik.spaghetticodingclub.domain.track.entity.TrackParticipants;
 import wercsmik.spaghetticodingclub.domain.track.repository.TrackParticipantsRepository;
 import wercsmik.spaghetticodingclub.domain.track.repository.TrackRepository;
@@ -55,5 +61,32 @@ public class TrackParticipantsService {
                         participant.getTrack().getTrackName(),
                         participant.getJoinedAt()))
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public TrackParticipantUpdateResponseDTO updateParticipantTrack(Long userId, Long oldTrackId, String newTrackName) {
+        // 관리자 권한 확인
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (!auth.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"))) {
+            throw new CustomException(ErrorCode.NO_AUTHENTICATION);
+        }
+
+        // 새 트랙의 존재 여부 확인
+        Track newTrack = trackRepository.findByTrackName(newTrackName)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOT_FOUND));
+
+        // 트랙 참여자 정보 조회
+        TrackParticipantId participantId = new TrackParticipantId(userId, oldTrackId);
+        TrackParticipants participant = trackParticipantsRepository.findById(participantId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 트랙 정보 업데이트
+        participant.updateTrack(newTrack);
+        trackParticipantsRepository.save(participant);
+
+        return TrackParticipantUpdateResponseDTO.builder()
+                .userId(userId)
+                .updatedTrackName(newTrack.getTrackName())
+                .build();
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
@@ -71,6 +71,10 @@ public class TrackParticipantsService {
             throw new CustomException(ErrorCode.NO_AUTHENTICATION);
         }
 
+        if (newTrackName == null || newTrackName.trim().isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_TRACK_NAME);
+        }
+
         // 새 트랙의 존재 여부 확인
         Track newTrack = trackRepository.findByTrackName(newTrackName)
                 .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOT_FOUND));


### PR DESCRIPTION
### 설명
관리자가 트랙 참여자의 트랙을 수정할 수 있도록 하는 기능입니다. 이 기능은 관리자 권한을 가진 사용자만이 접근할 수 있으며, 트랙 참여자의 기존 트랙 ID와 새로운 트랙 이름을 통해 트랙 정보를 업데이트합니다.

### 주요 변경 사항
- `TrackParticipantsService` 클래스에 `updateParticipantTrack` 메소드를 추가하여, 트랙 수정 로직을 처리합니다.
- `TrackParticipantsController`에 `updateParticipantTrack` 엔드포인트를 추가하여, URL 경로를 통해 사용자 ID와 기존 트랙 ID를 받고, 요청 본문을 통해 새 트랙 이름을 받습니다.
- 새로운 DTO `TrackParticipantUpdateResponseDTO`를 정의하여, 수정된 사용자 ID와 트랙 이름을 응답으로 반환합니다.

### 보안 및 권한
- 이 기능은 `@PreAuthorize` 어노테이션을 사용하여 `ROLE_ADMIN` 권한을 가진 사용자만 접근할 수 있습니다.
- 요청이 처리되기 전에 사용자의 권한을 검증합니다.

### 테스트
- 모든 변경 사항은 Postman을 통해 검증되었습니다.


### 첨부 이미지 및 자료
![스크린샷 2024-05-27 오후 12 46 45](https://github.com/Kim-s-Crew/SpaghettiCodingClub-BE/assets/129070298/53c50bf9-7d51-420d-8363-b154c43a46d0)