### PR TITLE
feat: 트랙명 수정

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackController.java
@@ -6,6 +6,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import wercsmik.spaghetticodingclub.domain.track.dto.TrackRequestDTO;
 import wercsmik.spaghetticodingclub.domain.track.dto.TrackResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackUpdateResponseDTO;
 import wercsmik.spaghetticodingclub.domain.track.service.TrackService;
 import wercsmik.spaghetticodingclub.global.auditing.BaseTimeEntity;
 import wercsmik.spaghetticodingclub.global.common.CommonResponse;
@@ -36,4 +37,16 @@ public class TrackController extends BaseTimeEntity {
 
         return ResponseEntity.ok().body(CommonResponse.of("트랙 전체 조회 성공", tracks));
     }
+
+    @PutMapping("/{trackId}")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    public ResponseEntity<CommonResponse<TrackUpdateResponseDTO>> updateTrack(
+            @PathVariable Long trackId,
+            @RequestBody TrackRequestDTO trackRequest) {
+
+        TrackUpdateResponseDTO updatedTrack = trackService.updateTrackName(trackId, trackRequest.getTrackName());
+
+        return ResponseEntity.ok().body(CommonResponse.of("트랙명 수정 성공", updatedTrack));
+    }
+
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackUpdateResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackUpdateResponseDTO.java
@@ -1,0 +1,15 @@
+package wercsmik.spaghetticodingclub.domain.track.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class TrackUpdateResponseDTO {
+
+    private Long trackId;
+
+    private String trackName;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/Track.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/Track.java
@@ -20,4 +20,8 @@ public class Track extends BaseTimeEntity {
 
     @Column(nullable = false, length = 50)
     private String trackName;
+
+    public void setTrackName(String trackName) {
+        this.trackName = trackName;
+    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wercsmik.spaghetticodingclub.domain.track.dto.TrackRequestDTO;
 import wercsmik.spaghetticodingclub.domain.track.dto.TrackResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackUpdateResponseDTO;
 import wercsmik.spaghetticodingclub.domain.track.entity.Track;
 import wercsmik.spaghetticodingclub.domain.track.repository.TrackRepository;
 import wercsmik.spaghetticodingclub.global.exception.CustomException;
@@ -56,4 +57,23 @@ public class TrackService {
                 .map(track -> new TrackResponseDTO(track.getTrackId(), track.getTrackName()))
                 .collect(Collectors.toList());
     }
+
+    @Transactional
+    public TrackUpdateResponseDTO updateTrackName(Long trackId, String newTrackName) {
+        if (newTrackName == null || newTrackName.trim().isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_TRACK_NAME);
+        }
+
+        Track track = trackRepository.findById(trackId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOT_FOUND));
+
+        track.setTrackName(newTrackName);
+        trackRepository.save(track);
+
+        return TrackUpdateResponseDTO.builder()
+                .trackId(track.getTrackId())
+                .trackName(track.getTrackName())
+                .build();
+    }
+
 }


### PR DESCRIPTION
### 설명
이 Pull Request는 트랙명 수정 기능을 구현합니다. 관리자만이 트랙의 이름을 수정할 수 있으며, 이를 통해 트랙 정보를 더욱 유동적으로 관리할 수 있습니다. 수정된 트랙 정보는 응답으로 반환되어 클라이언트가 변경 사항을 즉시 확인할 수 있습니다.

### 주요 변경 사항
- `TrackService`에 `updateTrackName` 메소드를 추가하여 트랙명을 업데이트하는 로직을 구현했습니다.
- `TrackController`에서 해당 서비스 메소드를 호출하는 새로운 PUT 엔드포인트 `/tracks/{trackId}`를 추가했습니다.
- 새로운 응답 DTO `TrackUpdateResponseDTO`를 추가하여 수정된 트랙명과 트랙 ID를 클라이언트에 반환합니다.
- `@PreAuthorize` 어노테이션을 사용하여 이 기능에 대한 접근을 관리자로 제한했습니다.

### 기대 효과
- 트랙 정보의 유지 관리가 용이해집니다.
- 관리자는 트랙 정보를 실시간으로 업데이트할 수 있으며, 이 변경 사항은 즉시 시스템에 반영됩니다.
- 시스템의 유연성이 향상되며 사용자 경험이 개선됩니다.

### 테스트 결과
- Postman을 통해 `updateTrackName` 메소드의 기능을 검증했습니다.

### API 명세서
![스크린샷 2024-05-27 오후 6 13 00](https://github.com/Kim-s-Crew/SpaghettiCodingClub-BE/assets/129070298/9e6b28d0-f2b9-427e-925d-272840db4e6f)