### PR TITLE
feat: 트랙 공지 생성

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackNoticeController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackNoticeController.java
@@ -1,0 +1,36 @@
+package wercsmik.spaghetticodingclub.domain.track.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackNoticeCreationRequestDTO;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackNoticeResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.service.TrackNoticeService;
+import wercsmik.spaghetticodingclub.global.common.CommonResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/tracks/{trackId}/notices")
+@PreAuthorize("hasAuthority('ROLE_ADMIN')")
+public class TrackNoticeController {
+
+    private final TrackNoticeService trackNoticeService;
+
+    @PostMapping
+    public ResponseEntity<CommonResponse<TrackNoticeResponseDTO>> createTrackNotice(
+            @PathVariable Long trackId,
+            @RequestBody TrackNoticeCreationRequestDTO requestDTO) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String userEmailOrUsername = authentication.getName();
+
+        TrackNoticeResponseDTO createdNotice = trackNoticeService.createTrackNotice(trackId, userEmailOrUsername, requestDTO);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CommonResponse.of("트랙 공지 생성 성공", createdNotice));
+    }
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackNoticeCreationRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackNoticeCreationRequestDTO.java
@@ -1,0 +1,13 @@
+package wercsmik.spaghetticodingclub.domain.track.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TrackNoticeCreationRequestDTO {
+
+    private String trackNoticeTitle;
+
+    private String trackNoticeContent;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackNoticeCreationRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackNoticeCreationRequestDTO.java
@@ -1,5 +1,6 @@
 package wercsmik.spaghetticodingclub.domain.track.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,7 +8,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public class TrackNoticeCreationRequestDTO {
 
+    @NotBlank(message = "트랙 공지 제목은 필수입니다.")
     private String trackNoticeTitle;
 
+    @NotBlank(message = "트랙 공지 내용은 필수입니다.")
     private String trackNoticeContent;
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackNoticeResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackNoticeResponseDTO.java
@@ -1,0 +1,28 @@
+package wercsmik.spaghetticodingclub.domain.track.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import wercsmik.spaghetticodingclub.domain.track.entity.TrackNotice;
+
+@Getter
+@AllArgsConstructor
+public class TrackNoticeResponseDTO {
+
+    private Long noticeId;
+
+    private Long trackId;
+
+    private Long userId;
+
+    private String trackNoticeTitle;
+
+    private String trackNoticeContent;
+
+    public TrackNoticeResponseDTO(TrackNotice trackNotice) {
+        this.noticeId = trackNotice.getNoticeId();
+        this.trackId = trackNotice.getTrack().getTrackId();
+        this.userId = trackNotice.getUser().getUserId();
+        this.trackNoticeTitle = trackNotice.getTrackNoticeTitle();
+        this.trackNoticeContent = trackNotice.getTrackNoticeContent();
+    }
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackNotice.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackNotice.java
@@ -1,0 +1,35 @@
+package wercsmik.spaghetticodingclub.domain.track.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import wercsmik.spaghetticodingclub.domain.user.entity.User;
+import wercsmik.spaghetticodingclub.global.auditing.BaseTimeEntity;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class TrackNotice extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long noticeId;
+
+    @Column(nullable = false, length = 200)
+    private String trackNoticeTitle;
+
+    @Column(nullable = false)
+    private String trackNoticeContent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trackId", nullable = false)
+    private Track track;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackNoticeRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackNoticeRepository.java
@@ -1,0 +1,7 @@
+package wercsmik.spaghetticodingclub.domain.track.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wercsmik.spaghetticodingclub.domain.track.entity.TrackNotice;
+
+public interface TrackNoticeRepository extends JpaRepository<TrackNotice, Long> {
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackNoticeService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackNoticeService.java
@@ -1,0 +1,60 @@
+package wercsmik.spaghetticodingclub.domain.track.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackNoticeCreationRequestDTO;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackNoticeResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.entity.Track;
+import wercsmik.spaghetticodingclub.domain.track.entity.TrackNotice;
+import wercsmik.spaghetticodingclub.domain.track.repository.TrackNoticeRepository;
+import wercsmik.spaghetticodingclub.domain.track.repository.TrackRepository;
+import wercsmik.spaghetticodingclub.domain.user.entity.User;
+import wercsmik.spaghetticodingclub.domain.user.repository.UserRepository;
+import wercsmik.spaghetticodingclub.global.exception.CustomException;
+import wercsmik.spaghetticodingclub.global.exception.ErrorCode;
+
+@Service
+@RequiredArgsConstructor
+public class TrackNoticeService {
+
+    private final TrackNoticeRepository trackNoticeRepository;
+    private final TrackRepository trackRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public TrackNoticeResponseDTO createTrackNotice(Long trackId, String userEmailOrUsername, TrackNoticeCreationRequestDTO requestDTO) {
+
+        Track track = trackRepository.findById(trackId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOT_FOUND));
+
+        if (requestDTO.getTrackNoticeTitle() == null || requestDTO.getTrackNoticeTitle().trim().isEmpty() ||
+                requestDTO.getTrackNoticeContent() == null || requestDTO.getTrackNoticeContent().trim().isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_NOTICE_CONTENT);
+        }
+
+        boolean isAdmin = SecurityContextHolder.getContext().getAuthentication()
+                .getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"));
+
+        if (!isAdmin) {
+            throw new CustomException(ErrorCode.NO_AUTHENTICATION);
+        }
+
+        User user = userRepository.findByEmail(userEmailOrUsername)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        TrackNotice notice = TrackNotice.builder()
+                .trackNoticeTitle(requestDTO.getTrackNoticeTitle())
+                .trackNoticeContent(requestDTO.getTrackNoticeContent())
+                .track(track)
+                .user(user)
+                .build();
+
+        TrackNotice savedNotice = trackNoticeRepository.save(notice);
+
+        return new TrackNoticeResponseDTO(savedNotice);
+    }
+}
+

--- a/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
@@ -39,6 +39,9 @@ public enum ErrorCode {
 
     INVALID_TRACK_NAME(400, "잘못된 트랙 이름입니다."),
 
+    // Track Notice
+    INVALID_NOTICE_CONTENT(400, "공지 내용이 누락되었습니다."),
+
 
     // Unlike
 


### PR DESCRIPTION
## 설명
이 Pull Request는 트랙명 수정 기능을 구현합니다. 관리자만이 트랙의 이름을 수정할 수 있으며, 이를 통해 트랙 정보를 더욱 유동적으로 관리할 수 있습니다. 수정된 트랙 정보는 응답으로 반환되어 클라이언트가 변경 사항을 즉시 확인할 수 있습니다.

## 주요 변경 사항
- `TrackService`에 `updateTrackName` 메소드를 추가하여 트랙명을 업데이트하는 로직을 구현했습니다.
- `TrackController`에서 해당 서비스 메소드를 호출하는 새로운 PUT 엔드포인트 `/tracks/{trackId}`를 추가했습니다.
- 새로운 응답 DTO `TrackUpdateResponseDTO`를 추가하여 수정된 트랙명과 트랙 ID를 클라이언트에 반환합니다.
- `@PreAuthorize` 어노테이션을 사용하여 이 기능에 대한 접근을 관리자로 제한했습니다.

## 기대 효과
- 트랙 정보의 유지 관리가 용이해집니다.
- 관리자는 트랙 정보를 실시간으로 업데이트할 수 있으며, 이 변경 사항은 즉시 시스템에 반영됩니다.
- 시스템의 유연성이 향상되며 사용자 경험이 개선됩니다.

## 테스트 결과
- Postman을 통해 `updateTrackName` 메소드의 기능을 검증했습니다.

## API 명세서
![스크린샷 2024-05-29 오전 1 26 05](https://github.com/Kim-s-Crew/SpaghettiCodingClub-BE/assets/129070298/58c3816b-177f-41bf-ad47-f93f700346f9)
