### PR TITLE
feat: 트랙 공지 전체 조회

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackNotice.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackNotice.java
@@ -26,7 +26,7 @@ public class TrackNotice extends BaseTimeEntity {
     private String trackNoticeContent;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "trackId", nullable = false)
+    @JoinColumn(name = "trackId", referencedColumnName = "trackId", nullable = false)
     private Track track;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipants.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackParticipants.java
@@ -34,6 +34,11 @@ public class TrackParticipants {
         this.track = newTrack;
     }
 
+    public Long getTrackId() {
+        return this.id.getTrackId();
+    }
+
+
     public static class TrackParticipantsBuilder {
         private Long userId;
         private Long trackId;

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackNoticeRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackNoticeRepository.java
@@ -3,5 +3,11 @@ package wercsmik.spaghetticodingclub.domain.track.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import wercsmik.spaghetticodingclub.domain.track.entity.TrackNotice;
 
+import java.util.List;
+import java.util.Set;
+
 public interface TrackNoticeRepository extends JpaRepository<TrackNotice, Long> {
+
+    List<TrackNotice> findAllByTrack_TrackIdIn(Set<Long> trackIds);
+
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackParticipantsRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackParticipantsRepository.java
@@ -11,4 +11,6 @@ public interface TrackParticipantsRepository extends JpaRepository<TrackParticip
     List<TrackParticipants> findByTrackTrackId(Long trackId);
 
     List<TrackParticipants> findByUserUserId(Long userId);
+
+    boolean existsById_UserIdAndId_TrackId(Long userId, Long trackId);
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/global/config/WebSecurityConfig.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/config/WebSecurityConfig.java
@@ -15,11 +15,15 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
 import wercsmik.spaghetticodingclub.domain.track.repository.TrackParticipantsRepository;
 import wercsmik.spaghetticodingclub.global.jwt.JwtAuthenticationFilter;
 import wercsmik.spaghetticodingclub.global.jwt.JwtAuthorizationFilter;
 import wercsmik.spaghetticodingclub.global.jwt.JwtUtil;
 import wercsmik.spaghetticodingclub.global.security.UserDetailsServiceImpl;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -55,6 +59,18 @@ public class WebSecurityConfig {
         filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
 
         return filter;
+    }
+
+    @Bean
+    public CorsConfiguration corsConfiguration() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList("https://spaghetticoding.shop", "http://43.202.186.51:8080", "http://localhost:3000/", "http://43.202.186.51:3000", "http://localhost:3000"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE"));
+        configuration.setAllowedHeaders(Arrays.asList("Origin", "Content-Type", "Accept"));
+        configuration.setAllowCredentials(true);
+        configuration.setExposedHeaders(List.of("Authorization"));
+
+        return configuration;
     }
 
     @Bean


### PR DESCRIPTION
#### 개요
이 Pull Request는 트랙 공지 API의 기능을 강화하며, 관리자와 일반 사용자의 접근성을 개선하는 새로운 로직을 도입합니다. 특히, 관리자는 특정 트랙 ID를 제공할 경우 해당 트랙의 공지만 조회할 수 있으며, 모든 공지를 조회하는 기능도 포함됩니다.

#### 변경 사항
1. **새로운 메소드 추가**:
   - 관리자가 특정 트랙의 공지만 조회할 수 있는 `getNoticesForTrack(Long trackId)` 메소드.
   - 사용자가 속한 트랙의 공지만 조회할 수 있는 `getNoticesForUserByTrack(Long userId, Long trackId)` 메소드.

2. **기능 개선**:
   - 관리자와 일반 사용자의 권한을 확인하여 적절한 공지만 조회하도록 보안 강화.
   - 트랙 ID가 유효하지 않거나 권한이 없는 경우에 대한 예외 처리 로직 강화.

3. **코드 최적화**:
   - 중복 코드 제거 및 공통 로직을 메서드로 분리하여 코드의 가독성 및 유지보수성 향상.

#### 테스트 
- Postman을 통해 새로운 메소드의 로직을 검증.
- Postman을 통해 API가 전체 시스템과 올바르게 통합되는지 확인.