### PR TITLE
feat: 트랙 공지 삭제

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackNoticeController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackNoticeController.java
@@ -56,4 +56,15 @@ public class TrackNoticeController {
         return ResponseEntity.ok().
                 body(CommonResponse.of("트랙 공지 전체 조회 성공", notices));
     }
+
+    @DeleteMapping("/{noticeId}")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    public ResponseEntity<CommonResponse<Void>> deleteTrackNotice(
+            @PathVariable Long trackId,
+            @PathVariable Long noticeId) {
+
+        trackNoticeService.deleteTrackNotice(noticeId, trackId);
+
+        return ResponseEntity.ok().body(CommonResponse.of("트랙 공지 삭제 성공", null));
+    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackNoticeService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackNoticeService.java
@@ -75,6 +75,22 @@ public class TrackNoticeService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional
+    public void deleteTrackNotice(Long noticeId, Long trackId) {
+
+        Track track = trackRepository.findById(trackId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOT_FOUND));
+
+        TrackNotice notice = trackNoticeRepository.findById(noticeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOTICE_NOT_FOUND));
+
+        if (!isAdmin()) {
+            throw new CustomException(ErrorCode.NO_AUTHENTICATION);
+        }
+
+        trackNoticeRepository.delete(notice);
+    }
+
 
     /*
         공통 로직을 메서드로 분리

--- a/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
@@ -39,8 +39,11 @@ public enum ErrorCode {
 
     INVALID_TRACK_NAME(400, "잘못된 트랙 이름입니다."),
 
+
     // Track Notice
     INVALID_NOTICE_CONTENT(400, "공지 내용이 누락되었습니다."),
+
+    TRACK_NOTICE_NOT_FOUND(400, "해당 트랙 공지사항을 찾을 수 없습니다."),
 
 
     // Unlike


### PR DESCRIPTION
트랙 공지 삭제 기능을 구현하였습니다. 이 기능은 관리자가 트랙 공지를 삭제할 수 있게 해줍니다. 

변경 사항:

1. `TrackNoticeService.java`: 공지를 삭제하는 `deleteTrackNotice` 메서드를 추가했습니다. 이 메서드는 공지 ID와 트랙 ID를 인자로 받아 해당 공지를 삭제합니다. 관리자가 아닌 경우 `CustomException`을 발생시킵니다.

2. `TrackNoticeController.java`: `deleteTrackNotice` 메서드를 호출하는 엔드포인트를 추가했습니다. 이 엔드포인트는 관리자 권한을 필요로 합니다.

3. `ErrorCode.java`: 관련된 에러 코드를 추가했습니다. 트랙이나 공지를 찾을 수 없는 경우, 또는 사용자가 관리자가 아닌 경우에 대한 에러 코드를 정의했습니다.

테스트:

이 기능은 Postman을 통해 검증되었습니다. 
테스트는 모든 예상 가능한 시나리오를 커버하며, 특히 권한이 없는 사용자가 공지를 삭제하려고 시도하는 경우를 테스트했습니다.

이 PR은 코드 리뷰를 위해 열려 있습니다. 피드백은 환영입니다.