### PR TITLE
feat: 트랙 공지 수정

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackNoticeController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackNoticeController.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import wercsmik.spaghetticodingclub.domain.track.dto.TrackNoticeCreationRequestDTO;
 import wercsmik.spaghetticodingclub.domain.track.dto.TrackNoticeResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackNoticeUpdateRequestDTO;
 import wercsmik.spaghetticodingclub.domain.track.service.TrackNoticeService;
 import wercsmik.spaghetticodingclub.global.common.CommonResponse;
 import wercsmik.spaghetticodingclub.global.security.UserDetailsImpl;
@@ -56,6 +57,19 @@ public class TrackNoticeController {
         return ResponseEntity.ok().
                 body(CommonResponse.of("트랙 공지 전체 조회 성공", notices));
     }
+
+    @PutMapping("/{noticeId}")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    public ResponseEntity<CommonResponse<TrackNoticeResponseDTO>> updateTrackNotice(
+            @PathVariable Long trackId,
+            @PathVariable Long noticeId,
+            @RequestBody TrackNoticeUpdateRequestDTO requestDTO) {
+
+        TrackNoticeResponseDTO updatedNotice = trackNoticeService.updateTrackNotice(trackId, noticeId, requestDTO);
+
+        return ResponseEntity.ok().body(CommonResponse.of("트랙 공지 수정 성공", updatedNotice));
+    }
+
 
     @DeleteMapping("/{noticeId}")
     @PreAuthorize("hasAuthority('ROLE_ADMIN')")

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackNoticeUpdateRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackNoticeUpdateRequestDTO.java
@@ -1,0 +1,11 @@
+package wercsmik.spaghetticodingclub.domain.track.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TrackNoticeUpdateRequestDTO {
+
+    private String trackNoticeTitle;
+
+    private String trackNoticeContent;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackNotice.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackNotice.java
@@ -32,4 +32,12 @@ public class TrackNotice extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId", nullable = false)
     private User user;
+
+    public void setTrackNoticeTitle(String trackNoticeTitle) {
+        this.trackNoticeTitle = trackNoticeTitle;
+    }
+
+    public void setTrackNoticeContent(String trackNoticeContent) {
+        this.trackNoticeContent = trackNoticeContent;
+    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackNoticeService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackNoticeService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wercsmik.spaghetticodingclub.domain.track.dto.TrackNoticeCreationRequestDTO;
 import wercsmik.spaghetticodingclub.domain.track.dto.TrackNoticeResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackNoticeUpdateRequestDTO;
 import wercsmik.spaghetticodingclub.domain.track.entity.Track;
 import wercsmik.spaghetticodingclub.domain.track.entity.TrackNotice;
 import wercsmik.spaghetticodingclub.domain.track.repository.TrackNoticeRepository;
@@ -74,6 +75,28 @@ public class TrackNoticeService {
                 .map(this::convertToDTO)
                 .collect(Collectors.toList());
     }
+
+    @Transactional
+    public TrackNoticeResponseDTO updateTrackNotice(Long trackId, Long noticeId, TrackNoticeUpdateRequestDTO requestDTO) {
+
+        if (!isAdmin()) {
+            throw new CustomException(ErrorCode.NO_AUTHENTICATION);
+        }
+
+        Track track = trackRepository.findById(trackId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOT_FOUND));
+
+        TrackNotice notice = trackNoticeRepository.findById(noticeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOTICE_NOT_FOUND));
+
+        notice.setTrackNoticeTitle(requestDTO.getTrackNoticeTitle());
+        notice.setTrackNoticeContent(requestDTO.getTrackNoticeContent());
+
+        TrackNotice updatedNotice = trackNoticeRepository.save(notice);
+
+        return new TrackNoticeResponseDTO(updatedNotice);
+    }
+
 
     @Transactional
     public void deleteTrackNotice(Long noticeId, Long trackId) {


### PR DESCRIPTION
#### 개요
이 Pull Request에서는 관리자가 트랙 공지를 수정할 수 있는 기능을 구현합니다. 이 기능은 시스템의 유연성을 향상시키고, 관리자가 공지사항을 시의적절하게 업데이트할 수 있게 합니다.

#### 변경 사항
1. **트랙 공지 수정 API**:
   - 관리자 권한을 가진 사용자만 트랙 공지를 수정할 수 있습니다.
   - 공지 제목과 내용을 업데이트하는 `PUT` 엔드포인트(`/tracks/notices/{noticeId}`)를 추가했습니다.

2. **서비스 로직 개선**:
   - `TrackNoticeService`에 `updateTrackNotice` 메서드를 추가하여, 공지 내용의 검증과 업데이트 로직을 구현했습니다.

3. **DTO 추가**:
   - 공지 수정을 위한 `TrackNoticeUpdateRequestDTO`를 새로 생성하여, API 요청에서 사용자 입력을 안전하게 처리합니다.

4. **권한 검증**:
   - 공지 수정 작업에 대한 접근 권한을 검증하는 로직을 강화했습니다.

#### 기대 효과
- **효율성 향상**: 관리자가 공지사항을 더 빠르고 쉽게 업데이트할 수 있습니다.
- **보안 강화**: 적절한 권한 검증을 통해 시스템의 안전성을 유지합니다.

#### Postman 테스트:
- Postman을 사용하여 API의 동작을 매뉴얼 테스트했습니다.
- 수정된 공지 내용이 정상적으로 반영되었고, 적절한 권한 없이 접근할 경우 에러 메시지가 반환되는 것을 확인했습니다.