### PR TITLE
feat: 트랙 공지 단일 조회

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackNoticeController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackNoticeController.java
@@ -39,6 +39,19 @@ public class TrackNoticeController {
                 .body(CommonResponse.of("트랙 공지 생성 성공", createdNotice));
     }
 
+    @GetMapping("/{noticeId}")
+    public ResponseEntity<CommonResponse<TrackNoticeResponseDTO>> getTrackNotice(
+            @PathVariable Long trackId,
+            @PathVariable Long noticeId) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = ((UserDetailsImpl) authentication.getPrincipal()).getUser().getUserId();
+
+        TrackNoticeResponseDTO notice = trackNoticeService.getTrackNotice(trackId, userId, noticeId);
+
+        return ResponseEntity.ok().body(CommonResponse.of("트랙 공지 조회 성공", notice));
+    }
+
     @GetMapping
     public ResponseEntity<CommonResponse<List<TrackNoticeResponseDTO>>> getNotices(
             @PathVariable Long trackId) {

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackNoticeService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackNoticeService.java
@@ -85,7 +85,6 @@ public class TrackNoticeService {
         TrackNotice notice = trackNoticeRepository.findById(noticeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOTICE_NOT_FOUND));
 
-
         if (isAdmin() || isUserNoticeAccessible(userId, notice.getTrack().getTrackId())) {
             return new TrackNoticeResponseDTO(notice);
         } else {

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackNoticeService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackNoticeService.java
@@ -76,6 +76,23 @@ public class TrackNoticeService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
+    public TrackNoticeResponseDTO getTrackNotice(Long trackId, Long userId, Long noticeId) {
+
+        Track track = trackRepository.findById(trackId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOT_FOUND));
+
+        TrackNotice notice = trackNoticeRepository.findById(noticeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOTICE_NOT_FOUND));
+
+
+        if (isAdmin() || isUserNoticeAccessible(userId, notice.getTrack().getTrackId())) {
+            return new TrackNoticeResponseDTO(notice);
+        } else {
+            throw new CustomException(ErrorCode.NO_AUTHENTICATION);
+        }
+    }
+
     @Transactional
     public TrackNoticeResponseDTO updateTrackNotice(Long trackId, Long noticeId, TrackNoticeUpdateRequestDTO requestDTO) {
 
@@ -147,6 +164,11 @@ public class TrackNoticeService {
     private TrackNoticeResponseDTO convertToDTO(TrackNotice trackNotice) {
 
         return new TrackNoticeResponseDTO(trackNotice);
+    }
+
+    private boolean isUserNoticeAccessible(Long userId, Long trackId) {
+
+        return trackParticipantRepository.existsById_UserIdAndId_TrackId(userId, trackId);
     }
 }
 


### PR DESCRIPTION
#### 개요
- 트랙 공지 단일 조회 기능을 구현하여, 관리자와 사용자가 트랙 공지를 조회할 수 있도록 함. 사용자는 자신이 속한 트랙의 공지만 조회 가능.

#### 변경 사항
1. **Service 계층 수정**: `TrackNoticeService`에 `getTrackNotice` 메소드를 추가하여, 사용자와 관리자의 권한을 검증 후 트랙 공지를 제공.
2. **Repository 계층 수정**: `TrackNoticeRepository`에 트랙 ID를 기준으로 공지를 조회하는 JPA 쿼리 메소드를 추가.
3. **Controller 계층 수정**: `TrackNoticeController`에 경로 변수를 사용하여 공지 ID에 따른 조회 엔드포인트를 설정.
4. **Exception Handling**: 적절한 예외 처리를 추가하여, 권한이 없거나 요청된 공지가 없는 경우 사용자에게 알려줄 수 있도록 함.

#### 테스트
- 관리자와 일반 사용자 계정을 통해 각각의 시나리오에 대한 접근성을 테스트. 관리자는 모든 트랙의 공지를 조회할 수 있고, 사용자는 자신이 속한 트랙의 공지만 조회할 수 있음을 확인.
- API 테스트를 포스트맨으로 수행하여, 모든 가능한 경우에 대한 응답과 예외가 적절히 처리되는지 검증.

#### 기대 효과
- 이 기능을 통해 플랫폼 사용자가 더욱 유연하게 정보를 접근할 수 있으며, 관리자는 효율적인 트랙 관리가 가능해짐.
- 사용자 경험 개선 및 시스템의 안정성 향상.