### PR TITLE
fix: 트랙 참여자의 트랙 수정기능의 수정

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackParticipantsController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackParticipantsController.java
@@ -39,6 +39,6 @@ public class TrackParticipantsController {
         TrackParticipantUpdateResponseDTO updatedInfo = trackParticipantsService.updateParticipantTrack(
                 userId, oldTrackId, trackUpdateRequest.getNewTrackName());
 
-        return ResponseEntity.ok().body(CommonResponse.of("트랙 참가자의 트랙 수정 성공", updatedInfo));
+        return ResponseEntity.ok().body(CommonResponse.of("트랙 참여자의 트랙 수정 성공", updatedInfo));
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackParticipantsController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackParticipantsController.java
@@ -37,7 +37,7 @@ public class TrackParticipantsController {
             @RequestBody TrackUpdateRequestDTO trackUpdateRequest) {
 
         TrackParticipantUpdateResponseDTO updatedInfo = trackParticipantsService.updateParticipantTrack(
-                userId, oldTrackId, trackUpdateRequest.getNewTrackName());
+                userId, oldTrackId, trackUpdateRequest.getNewTrackId());
 
         return ResponseEntity.ok().body(CommonResponse.of("트랙 참여자의 트랙 수정 성공", updatedInfo));
     }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackUpdateRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackUpdateRequestDTO.java
@@ -7,9 +7,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class TrackUpdateRequestDTO {
 
-    private String newTrackName;
+    private Long newTrackId;
 
-    public TrackUpdateRequestDTO(String newTrackName) {
-        this.newTrackName = newTrackName;
+    public TrackUpdateRequestDTO(Long newTrackId) {
+        this.newTrackId = newTrackId;
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackRepository.java
@@ -10,4 +10,6 @@ public interface TrackRepository extends JpaRepository<Track, Long> {
     boolean existsByTrackName(String trackName);
 
     Optional<Track> findByTrackName(String trackName);
+
+
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
@@ -64,19 +64,15 @@ public class TrackParticipantsService {
     }
 
     @Transactional
-    public TrackParticipantUpdateResponseDTO updateParticipantTrack(Long userId, Long oldTrackId, String newTrackName) {
+    public TrackParticipantUpdateResponseDTO updateParticipantTrack(Long userId, Long oldTrackId, Long newTrackId) {
         // 관리자 권한 확인
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (!auth.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"))) {
             throw new CustomException(ErrorCode.NO_AUTHENTICATION);
         }
 
-        if (newTrackName == null || newTrackName.trim().isEmpty()) {
-            throw new CustomException(ErrorCode.INVALID_TRACK_NAME);
-        }
-
         // 새 트랙의 존재 여부 확인
-        Track newTrack = trackRepository.findByTrackName(newTrackName)
+        Track newTrack = trackRepository.findById(newTrackId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOT_FOUND));
 
         // 트랙 참여자 정보 조회

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
@@ -84,9 +84,17 @@ public class TrackParticipantsService {
         TrackParticipants participant = trackParticipantsRepository.findById(participantId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        // 트랙 정보 업데이트
-        participant.updateTrack(newTrack);
-        trackParticipantsRepository.save(participant);
+        // 기존 트랙 참여자 정보 삭제
+        trackParticipantsRepository.delete(participant);
+
+        // 새로운 트랙 참여자 정보 생성
+        TrackParticipants newParticipant = TrackParticipants.builder()
+                .user(participant.getUser())
+                .track(newTrack)
+                .joinedAt(LocalDateTime.now())
+                .build();
+
+        trackParticipantsRepository.save(newParticipant);
 
         return TrackParticipantUpdateResponseDTO.builder()
                 .userId(userId)


### PR DESCRIPTION
이 PR은 `TrackParticipantsService` 및 `TrackParticipantsController` 클래스의 `updateParticipantTrack` 메소드를 리팩터링하여 새로운 트랙의 이름 대신 ID를 받도록 변경했습니다. 이 변경으로 여러 가지 이점을 제공합니다:

1. **안정성**: 트랙 ID는 고유하며 변경되지 않아 트랙 이름보다 더 안정적인 식별자입니다. 트랙 이름은 변경될 수 있습니다.
2. **성능**: ID를 사용하면 데이터베이스 쿼리가 더 빠르고 효율적일 수 있습니다.

주요 변경 사항은 다음과 같습니다:

- `TrackUpdateRequestDTO` 클래스에 `newTrackId` 필드를 추가했습니다.
- `TrackParticipantsController` 클래스의 `updateParticipantTrack` 메소드를 리팩터링하여 `TrackUpdateRequestDTO` 객체를 받도록 수정했습니다.
- `TrackParticipantsService` 클래스의 `updateParticipantTrack` 메소드를 리팩터링하여 새 트랙의 ID를 사용하여 트랙 엔티티를 찾도록 했습니다.
- 더 이상 필요하지 않은 `TrackRepository` 인터페이스에서 `findByTrackName` 메소드를 제거했습니다.