### PR TITLE
feat: 트랙 주차 생성

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackWeekController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackWeekController.java
@@ -1,0 +1,31 @@
+package wercsmik.spaghetticodingclub.domain.track.controller;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackWeekCreationRequestDTO;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackWeekCreationResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.service.TrackWeekService;
+import wercsmik.spaghetticodingclub.global.common.CommonResponse;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/tracks/{trackId}/weeks")
+public class TrackWeekController {
+
+    private final TrackWeekService trackWeekService;
+
+    @PostMapping
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    public ResponseEntity<CommonResponse<TrackWeekCreationResponseDTO>> createTrackWeek(
+            @PathVariable Long trackId,
+            @RequestBody TrackWeekCreationRequestDTO requestDTO) {
+
+        TrackWeekCreationResponseDTO trackWeek = trackWeekService.createTrackWeek(trackId, requestDTO);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CommonResponse.of("트랙 주차 생성 성공", trackWeek));
+    }
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackWeekCreationRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackWeekCreationRequestDTO.java
@@ -1,0 +1,15 @@
+package wercsmik.spaghetticodingclub.domain.track.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class TrackWeekCreationRequestDTO {
+
+    private String weekName;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackWeekCreationResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackWeekCreationResponseDTO.java
@@ -1,0 +1,20 @@
+package wercsmik.spaghetticodingclub.domain.track.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class TrackWeekCreationResponseDTO {
+
+    private Long trackWeekId;
+
+    private String weekName;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackWeek.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackWeek.java
@@ -1,0 +1,36 @@
+package wercsmik.spaghetticodingclub.domain.track.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wercsmik.spaghetticodingclub.global.auditing.BaseTimeEntity;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "TrackWeeks")
+public class TrackWeek extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long trackWeekId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trackId", nullable = false)
+    private Track track;
+
+    @Column(nullable = false, length = 50)
+    private String weekName;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    @Column(nullable = false)
+    private LocalDate endDate;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackWeekRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/repository/TrackWeekRepository.java
@@ -1,0 +1,11 @@
+package wercsmik.spaghetticodingclub.domain.track.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wercsmik.spaghetticodingclub.domain.track.entity.TrackWeek;
+
+import java.util.List;
+
+public interface TrackWeekRepository extends JpaRepository<TrackWeek, Long> {
+
+    List<TrackWeek> findByTrack_TrackId(Long trackId);
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackWeekService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackWeekService.java
@@ -27,6 +27,8 @@ public class TrackWeekService {
     @Transactional
     public TrackWeekCreationResponseDTO createTrackWeek(Long trackId, TrackWeekCreationRequestDTO requestDTO) {
 
+        validateDateRange(requestDTO.getStartDate(), requestDTO.getEndDate());
+
         if (!isAdmin()) {
             throw new CustomException(ErrorCode.NO_AUTHENTICATION);
         }
@@ -76,5 +78,15 @@ public class TrackWeekService {
 
         return SecurityContextHolder.getContext().getAuthentication()
                 .getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"));
+    }
+
+    private void validateDateRange(LocalDate startDate, LocalDate endDate) {
+
+        if (startDate.isBefore(LocalDate.now())) {
+            throw new CustomException(ErrorCode.START_DATE_BEFORE_CURRENT);
+        }
+        if (endDate.isBefore(startDate)) {
+            throw new CustomException(ErrorCode.INVALID_DATE_RANGE);
+        }
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackWeekService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackWeekService.java
@@ -1,0 +1,80 @@
+package wercsmik.spaghetticodingclub.domain.track.service;
+
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackWeekCreationRequestDTO;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackWeekCreationResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.entity.Track;
+import wercsmik.spaghetticodingclub.domain.track.entity.TrackWeek;
+import wercsmik.spaghetticodingclub.domain.track.repository.TrackRepository;
+import wercsmik.spaghetticodingclub.domain.track.repository.TrackWeekRepository;
+import wercsmik.spaghetticodingclub.global.exception.CustomException;
+import wercsmik.spaghetticodingclub.global.exception.ErrorCode;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class TrackWeekService {
+
+    private final TrackWeekRepository trackWeekRepository;
+    private final TrackRepository trackRepository;
+
+    @Transactional
+    public TrackWeekCreationResponseDTO createTrackWeek(Long trackId, TrackWeekCreationRequestDTO requestDTO) {
+
+        if (!isAdmin()) {
+            throw new CustomException(ErrorCode.NO_AUTHENTICATION);
+        }
+
+        Track track = trackRepository.findById(trackId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOT_FOUND));
+
+        validateTrackWeekDates(trackId, requestDTO.getStartDate(), requestDTO.getEndDate());
+
+        TrackWeek trackWeek = TrackWeek.builder()
+                .track(track)
+                .weekName(requestDTO.getWeekName())
+                .startDate(requestDTO.getStartDate())
+                .endDate(requestDTO.getEndDate())
+                .build();
+
+        TrackWeek savedTrackWeek = trackWeekRepository.save(trackWeek);
+
+        return convertToDto(savedTrackWeek);
+    }
+
+    /*
+        공통 로직을 메서드로 분리
+     */
+
+    private TrackWeekCreationResponseDTO convertToDto(TrackWeek trackWeek) {
+
+        return TrackWeekCreationResponseDTO.builder()
+                .trackWeekId(trackWeek.getTrackWeekId())
+                .weekName(trackWeek.getWeekName())
+                .startDate(trackWeek.getStartDate())
+                .endDate(trackWeek.getEndDate())
+                .build();
+    }
+
+    private void validateTrackWeekDates(Long trackId, LocalDate startDate, LocalDate endDate) {
+
+        List<TrackWeek> existingWeeks = trackWeekRepository.findByTrack_TrackId(trackId);
+        for (TrackWeek week : existingWeeks) {
+            if (week.getStartDate().isBefore(endDate) && week.getEndDate().isAfter(startDate)) {
+                throw new CustomException(ErrorCode.TRACK_WEEK_OVERLAP);
+            }
+        }
+    }
+
+    private boolean isAdmin() {
+
+        return SecurityContextHolder.getContext().getAuthentication()
+                .getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"));
+    }
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
@@ -8,7 +8,7 @@ public enum ErrorCode {
     // Assessment
     ASSESSMENT_NOT_FOUND(404, "평가 정보가 존재하지 않습니다."),
 
-    INVALID_ASSESSMENT_DATA(400,"평가 데이터가 유효하지 않습니다."),
+    INVALID_ASSESSMENT_DATA(400, "평가 데이터가 유효하지 않습니다."),
 
 
     // Auth
@@ -50,6 +50,10 @@ public enum ErrorCode {
 
     // Track Week
     TRACK_WEEK_OVERLAP(400, "주차 기간이 겹칩니다."),
+
+    INVALID_DATE_RANGE(400, "종료일은 시작일보다 이전일 수 없습니다."),
+
+    START_DATE_BEFORE_CURRENT(400, "시작일은 현재 날짜보다 이전일 수 없습니다."),
 
 
     // Unlike

--- a/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
@@ -48,6 +48,10 @@ public enum ErrorCode {
     TRACK_NOTICE_NOT_FOUND(400, "해당 트랙 공지사항을 찾을 수 없습니다."),
 
 
+    // Track Week
+    TRACK_WEEK_OVERLAP(400, "주차 기간이 겹칩니다."),
+
+
     // Unlike
 
 


### PR DESCRIPTION
### 설명:

이 PR은 트랙 주차 생성 기능을 개선하고, 필요한 날짜 유효성 검사를 추가하는 것을 목표로 합니다. 기존 시스템에서 트랙 주차를 생성할 때 일부 유효성 검사가 누락되어, 논리적으로 부적합한 날짜 입력을 방지하는 로직을 강화하였습니다.

#### 주요 변경 사항:
1. **트랙 주차 생성 로직**: `TrackWeekController`에 `/tracks/{trackId}/weeks` 엔드포인트를 통해 트랙 주차를 생성하는 기능을 구현합니다.
2. **날짜 유효성 검사 추가**:
   - 시작일은 현재 날짜 이후여야 하며, 종료일은 시작일 이후가 되어야 합니다.
   - 유효성 검사는 `TrackWeekService` 레벨에서 수행되며, DTO에서는 날짜 형식만을 검증합니다.
   - 위 조건을 만족하지 않을 때는 `ErrorCode`에 정의된 `START_DATE_BEFORE_CURRENT`와 `INVALID_DATE_RANGE`를 사용하여 예외를 발생시킵니다.

3. **예외 처리 강화**: 서비스 레벨과 컨트롤러 레벨에서의 예외 처리를 강화하여 API 사용자에게 명확한 에러 메시지를 제공합니다.

#### 배경:
이 변경은 사용자가 시스템을 보다 효과적으로 사용할 수 있도록 지원하고, 데이터 무결성을 보장하기 위해 필요합니다. 이를 통해 트랙 관리가 더욱 효율적이고 오류 없이 수행될 수 있습니다.

#### 테스트 :
- 포스트맨(Postman)을 사용하여 API 엔드포인트에 대한 통합 테스트를 수행하였습니다.
- 불가능한 날짜 입력 시 API가 적절한 에러 코드와 메시지를 반환하는지 확인하였습니다.