### PR TITLE
feat: 트랙 주차 수정

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackWeekController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackWeekController.java
@@ -7,6 +7,8 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import wercsmik.spaghetticodingclub.domain.track.dto.TrackWeekCreationRequestDTO;
 import wercsmik.spaghetticodingclub.domain.track.dto.TrackWeekCreationResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackWeekUpdateRequestDTO;
+import wercsmik.spaghetticodingclub.domain.track.dto.TrackWeekUpdateResponseDTO;
 import wercsmik.spaghetticodingclub.domain.track.service.TrackWeekService;
 import wercsmik.spaghetticodingclub.global.common.CommonResponse;
 
@@ -27,5 +29,17 @@ public class TrackWeekController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.of("트랙 주차 생성 성공", trackWeek));
+    }
+
+    @PutMapping("/{weekId}")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    public ResponseEntity<CommonResponse<TrackWeekUpdateResponseDTO>> updateTrackWeek(
+            @PathVariable Long trackId,
+            @PathVariable Long weekId,
+            @RequestBody TrackWeekUpdateRequestDTO requestDTO) {
+
+        TrackWeekUpdateResponseDTO trackWeek = trackWeekService.updateTrackWeek(trackId, weekId, requestDTO);
+
+        return ResponseEntity.ok(CommonResponse.of("트랙 주차 수정 성공", trackWeek));
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackWeekUpdateRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackWeekUpdateRequestDTO.java
@@ -1,0 +1,15 @@
+package wercsmik.spaghetticodingclub.domain.track.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class TrackWeekUpdateRequestDTO {
+
+    private String weekName;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackWeekUpdateResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackWeekUpdateResponseDTO.java
@@ -1,0 +1,55 @@
+package wercsmik.spaghetticodingclub.domain.track.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class TrackWeekUpdateResponseDTO {
+
+    private final Long trackWeekId;
+
+    private final String weekName;
+
+    private final LocalDate startDate;
+
+    private final LocalDate endDate;
+
+    private TrackWeekUpdateResponseDTO(Builder builder) {
+        this.trackWeekId = builder.trackWeekId;
+        this.weekName = builder.weekName;
+        this.startDate = builder.startDate;
+        this.endDate = builder.endDate;
+    }
+
+    public static class Builder {
+        private Long trackWeekId;
+        private String weekName;
+        private LocalDate startDate;
+        private LocalDate endDate;
+
+        public Builder trackWeekId(Long trackWeekId) {
+            this.trackWeekId = trackWeekId;
+            return this;
+        }
+
+        public Builder weekName(String weekName) {
+            this.weekName = weekName;
+            return this;
+        }
+
+        public Builder startDate(LocalDate startDate) {
+            this.startDate = startDate;
+            return this;
+        }
+
+        public Builder endDate(LocalDate endDate) {
+            this.endDate = endDate;
+            return this;
+        }
+
+        public TrackWeekUpdateResponseDTO build() {
+            return new TrackWeekUpdateResponseDTO(this);
+        }
+    }
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackWeek.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/entity/TrackWeek.java
@@ -33,4 +33,16 @@ public class TrackWeek extends BaseTimeEntity {
 
     @Column(nullable = false)
     private LocalDate endDate;
+
+    public void setWeekName(String weekName) {
+        this.weekName = weekName;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackWeekService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackWeekService.java
@@ -53,6 +53,7 @@ public class TrackWeekService {
 
     @Transactional
     public TrackWeekUpdateResponseDTO updateTrackWeek(Long trackId, Long weekId, TrackWeekUpdateRequestDTO requestDTO) {
+
         if (!isAdmin()) {
             throw new CustomException(ErrorCode.NO_AUTHENTICATION);
         }

--- a/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
@@ -55,6 +55,8 @@ public enum ErrorCode {
 
     START_DATE_BEFORE_CURRENT(400, "시작일은 현재 날짜보다 이전일 수 없습니다."),
 
+    TRACK_WEEK_NOT_FOUND(400, "해당 트랙 주차를 찾을 수 없습니다."),
+
 
     // Unlike
 


### PR DESCRIPTION
### 개요
- 이 PR은 관리자가 트랙 주차의 이름, 시작일, 종료일을 선택적으로 수정할 수 있는 기능을 구현합니다.

### 변경 사항
- `TrackWeekService`에 `updateTrackWeek` 메서드를 수정하여 선택적으로 필드를 업데이트할 수 있도록 했습니다.
- 시작일이 현재 날짜보다 이전이거나, 종료일이 시작일보다 이전일 경우 예외를 처리하는 로직을 추가했습니다.
- `TrackWeekUpdateRequestDTO`를 사용하여 요청 데이터를 수신하고, 유효성 검사를 수행합니다.
- `TrackWeekUpdateResponseDTO`를 통해 수정된 트랙 주차 정보를 응답합니다.

### 예상 효과
- 관리자는 필요에 따라 트랙 주차 정보의 일부만 수정할 수 있으며, 데이터 무결성을 유지할 수 있습니다.
- 사용자 경험이 개선되고, 데이터 처리의 유연성이 향상됩니다.

### 주의사항
- 시작일은 현재 날짜 이후로만 설정 가능합니다.
- 종료일은 시작일 이후로만 설정 가능합니다.
- 관리자 권한이 필요한 API입니다.