### PR TITLE
feat: 트랙 전체 주차 조회

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackWeekController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/controller/TrackWeekController.java
@@ -5,12 +5,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-import wercsmik.spaghetticodingclub.domain.track.dto.TrackWeekCreationRequestDTO;
-import wercsmik.spaghetticodingclub.domain.track.dto.TrackWeekCreationResponseDTO;
-import wercsmik.spaghetticodingclub.domain.track.dto.TrackWeekUpdateRequestDTO;
-import wercsmik.spaghetticodingclub.domain.track.dto.TrackWeekUpdateResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.dto.*;
 import wercsmik.spaghetticodingclub.domain.track.service.TrackWeekService;
 import wercsmik.spaghetticodingclub.global.common.CommonResponse;
+
+import java.util.List;
 
 @RestController
 @AllArgsConstructor
@@ -30,6 +29,15 @@ public class TrackWeekController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.of("트랙 주차 생성 성공", trackWeek));
     }
+
+    @GetMapping
+    public ResponseEntity<CommonResponse<List<TrackWeekListResponseDTO>>> getAllTrackWeeks(
+            @PathVariable Long trackId) {
+
+        return ResponseEntity.ok()
+                .body(CommonResponse.of("트랙 주차 조회 성공", trackWeekService.findAllTrackWeeksByTrackId(trackId)));
+    }
+
 
     @PutMapping("/{weekId}")
     @PreAuthorize("hasAuthority('ROLE_ADMIN')")

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackWeekListResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/dto/TrackWeekListResponseDTO.java
@@ -1,0 +1,21 @@
+package wercsmik.spaghetticodingclub.domain.track.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class TrackWeekListResponseDTO {
+
+    private Long trackWeekId;
+
+    private String weekName;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackWeekService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackWeekService.java
@@ -5,10 +5,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import wercsmik.spaghetticodingclub.domain.track.dto.TrackWeekCreationRequestDTO;
-import wercsmik.spaghetticodingclub.domain.track.dto.TrackWeekCreationResponseDTO;
-import wercsmik.spaghetticodingclub.domain.track.dto.TrackWeekUpdateRequestDTO;
-import wercsmik.spaghetticodingclub.domain.track.dto.TrackWeekUpdateResponseDTO;
+import wercsmik.spaghetticodingclub.domain.track.dto.*;
 import wercsmik.spaghetticodingclub.domain.track.entity.Track;
 import wercsmik.spaghetticodingclub.domain.track.entity.TrackWeek;
 import wercsmik.spaghetticodingclub.domain.track.repository.TrackRepository;
@@ -19,6 +16,7 @@ import wercsmik.spaghetticodingclub.global.exception.ErrorCode;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
@@ -48,7 +46,17 @@ public class TrackWeekService {
 
         trackWeekRepository.save(trackWeek);
 
-        return convertToDTO(trackWeek);
+        return convertToCreationDTO(trackWeek);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TrackWeekListResponseDTO> findAllTrackWeeksByTrackId(Long trackId) {
+
+        List<TrackWeek> trackWeeks = trackWeekRepository.findByTrack_TrackId(trackId);
+
+        return trackWeeks.stream()
+                .map(this::convertToListDTO)
+                .collect(Collectors.toList());
     }
 
     @Transactional
@@ -88,9 +96,19 @@ public class TrackWeekService {
         });
     }
 
-    private TrackWeekCreationResponseDTO convertToDTO(TrackWeek trackWeek) {
+    private TrackWeekCreationResponseDTO convertToCreationDTO(TrackWeek trackWeek) {
 
         return TrackWeekCreationResponseDTO.builder()
+                .trackWeekId(trackWeek.getTrackWeekId())
+                .weekName(trackWeek.getWeekName())
+                .startDate(trackWeek.getStartDate())
+                .endDate(trackWeek.getEndDate())
+                .build();
+    }
+
+    private TrackWeekListResponseDTO convertToListDTO(TrackWeek trackWeek) {
+
+        return TrackWeekListResponseDTO.builder()
                 .trackWeekId(trackWeek.getTrackWeekId())
                 .weekName(trackWeek.getWeekName())
                 .startDate(trackWeek.getStartDate())


### PR DESCRIPTION
### 설명
이 PR은 트랙 주차 전체 조회 기능을 추가하고, `TrackWeekService` 내의 DTO 변환 메소드의 이름을 명확화하여, 생성, 수정, 조회 기능에서 반환되는 DTO 타입을 더 명확하게 구분하고자 합니다. 이러한 개선은 서비스의 기능 확장과 동시에 코드의 가독성 및 유지보수성을 크게 향상시킬 것입니다.

### 주요 변경 사항
- **전체 조회 기능 추가**: `TrackWeekService`에 `findAllTrackWeeksByTrackId` 메소드를 추가하여 지정된 트랙 ID에 대한 모든 주차 정보를 조회할 수 있는 기능을 구현하였습니다.
- **DTO 변환 메소드 이름 변경**: `convertToDTO` 메소드를 기능에 따라 `convertToCreationDTO`와 `convertToListDTO`로 분리하여 반환되는 DTO의 용도를 명확하게 구분하였습니다.
- **Controller 업데이트**: `TrackWeekController`에 전체 조회를 위한 GET 엔드포인트를 추가하여 외부에서 접근 가능하게 구성하였습니다.

### 기대 효과
- **기능성 향상**: 사용자 및 관리자는 특정 트랙에 대한 모든 주차 정보를 쉽게 조회할 수 있습니다.
- **코드 가독성 향상**: 메소드명을 통해 반환되는 객체의 종류를 즉시 이해할 수 있습니다, 또한 각각의 용도에 맞는 DTO 변환을 명확히 함으로써 잠재적인 오류의 범위를 줄일 수 있습니다.
- **유지보수성 강화**: 메소드의 명확한 명명규칙은 향후 코드 수정 시 오류 가능성을 줄이고, 개발자가 기능과 관련된 부분을 빠르게 이해하고 접근할 수 있게 도와줍니다.