### PR TITLE
feat: 팀 생성

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/team/controller/TeamController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/team/controller/TeamController.java
@@ -1,4 +1,33 @@
 package wercsmik.spaghetticodingclub.domain.team.controller;
 
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import wercsmik.spaghetticodingclub.domain.team.dto.TeamCreationRequestDTO;
+import wercsmik.spaghetticodingclub.domain.team.dto.TeamCreationResponseDTO;
+import wercsmik.spaghetticodingclub.domain.team.service.TeamService;
+import wercsmik.spaghetticodingclub.global.common.CommonResponse;
+
+@RestController
+@RequestMapping("/tracks/{trackId}/trackWeeks/{trackWeekId}/teams")
+@AllArgsConstructor
 public class TeamController {
+
+    private final TeamService teamService;
+
+    @PostMapping
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    public ResponseEntity<CommonResponse<TeamCreationResponseDTO>> createTeam(
+            @PathVariable Long trackId,
+            @PathVariable Long trackWeekId,
+            @RequestBody TeamCreationRequestDTO requestDTO) {
+
+        TeamCreationResponseDTO responseDTO = teamService.createTeam(trackId, trackWeekId, requestDTO);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CommonResponse.of("팀 생성 성공", responseDTO));
+    }
+
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/team/dto/TeamCreationRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/team/dto/TeamCreationRequestDTO.java
@@ -1,0 +1,15 @@
+package wercsmik.spaghetticodingclub.domain.team.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class TeamCreationRequestDTO {
+
+    private String teamName;
+
+    private List<Long> memberIds;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/team/dto/TeamCreationResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/team/dto/TeamCreationResponseDTO.java
@@ -1,0 +1,18 @@
+package wercsmik.spaghetticodingclub.domain.team.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class TeamCreationResponseDTO {
+
+    private Long teamId;
+
+    private String teamName;
+
+    private List<Map<String, Object>> members;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/team/dto/TeamRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/team/dto/TeamRequestDTO.java
@@ -1,4 +1,0 @@
-package wercsmik.spaghetticodingclub.domain.team.dto;
-
-public class TeamRequestDTO {
-}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/team/dto/TeamResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/team/dto/TeamResponseDTO.java
@@ -1,4 +1,0 @@
-package wercsmik.spaghetticodingclub.domain.team.dto;
-
-public class TeamResponseDTO {
-}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/team/entity/Team.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/team/entity/Team.java
@@ -1,4 +1,48 @@
 package wercsmik.spaghetticodingclub.domain.team.entity;
 
-public class Team {
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wercsmik.spaghetticodingclub.domain.track.entity.TrackWeek;
+import wercsmik.spaghetticodingclub.domain.user.entity.User;
+import wercsmik.spaghetticodingclub.global.auditing.BaseTimeEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Team extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long teamId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trackWeekId", nullable = false)
+    private TrackWeek trackWeek;
+
+    @Column(length = 50, nullable = false)
+    private String teamName;
+
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<User> members = new ArrayList<>();
+
+    //TODO(은채): 팀리더 설정
+
+    public static class TeamBuilder {
+        public TeamBuilder members(List<User> members) {
+            if (this.members == null) {
+                this.members = new ArrayList<>();
+            }
+            this.members.addAll(members);
+            return this;
+        }
+    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/team/entity/TeamMember.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/team/entity/TeamMember.java
@@ -1,0 +1,36 @@
+package wercsmik.spaghetticodingclub.domain.team.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import wercsmik.spaghetticodingclub.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "TeamMembers")
+public class TeamMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long teamMemberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "teamId", nullable = false)
+    private Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    @CreatedDate
+    private LocalDateTime joinedAt;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/team/repository/TeamMemberRepository.java
@@ -1,0 +1,7 @@
+package wercsmik.spaghetticodingclub.domain.team.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wercsmik.spaghetticodingclub.domain.team.entity.TeamMember;
+
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/team/repository/TeamRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/team/repository/TeamRepository.java
@@ -1,4 +1,7 @@
 package wercsmik.spaghetticodingclub.domain.team.repository;
 
-public interface TeamRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import wercsmik.spaghetticodingclub.domain.team.entity.Team;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/team/service/TeamService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/team/service/TeamService.java
@@ -1,4 +1,86 @@
 package wercsmik.spaghetticodingclub.domain.team.service;
 
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import wercsmik.spaghetticodingclub.domain.team.dto.TeamCreationRequestDTO;
+import wercsmik.spaghetticodingclub.domain.team.dto.TeamCreationResponseDTO;
+import wercsmik.spaghetticodingclub.domain.team.entity.Team;
+import wercsmik.spaghetticodingclub.domain.team.repository.TeamRepository;
+import wercsmik.spaghetticodingclub.domain.track.entity.Track;
+import wercsmik.spaghetticodingclub.domain.track.entity.TrackWeek;
+import wercsmik.spaghetticodingclub.domain.track.repository.TrackRepository;
+import wercsmik.spaghetticodingclub.domain.track.repository.TrackWeekRepository;
+import wercsmik.spaghetticodingclub.domain.user.entity.User;
+import wercsmik.spaghetticodingclub.domain.user.repository.UserRepository;
+import wercsmik.spaghetticodingclub.global.exception.CustomException;
+import wercsmik.spaghetticodingclub.global.exception.ErrorCode;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
 public class TeamService {
+
+    private final TeamRepository teamRepository;
+    private final UserRepository userRepository;
+    private final TrackRepository trackRepository;
+    private final TrackWeekRepository trackWeekRepository;
+
+    @Transactional
+    public TeamCreationResponseDTO createTeam(Long trackId, Long trackWeekId, TeamCreationRequestDTO requestDTO) {
+
+        Track track = trackRepository.findById(trackId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOT_FOUND));
+
+        TrackWeek trackWeek = trackWeekRepository.findById(trackWeekId)
+                .orElseThrow(() -> new CustomException(ErrorCode.TRACK_WEEK_NOT_FOUND));
+
+        if (!isAdmin()) {
+            throw new CustomException(ErrorCode.NO_AUTHENTICATION);
+        }
+
+        List<Long> memberIds = requestDTO.getMemberIds();
+        List<User> members = userRepository.findAllById(memberIds);
+
+        if (members.size() != memberIds.size()) {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        Team team = Team.builder()
+                .trackWeek(trackWeek)
+                .teamName(requestDTO.getTeamName())
+                .members(members)
+                .build();
+
+        team = teamRepository.save(team);
+
+        List<Map<String, Object>> memberDetails = members.stream()
+                .map(member -> {
+                    Map<String, Object> details = new HashMap<>();
+                    details.put("userId", member.getUserId());
+                    details.put("username", member.getUsername());
+                    return details;
+                })
+                .collect(Collectors.toList());
+
+        return new TeamCreationResponseDTO(team.getTeamId(), team.getTeamName(), memberDetails);
+    }
+
+
+
+    /*
+        공통 로직을 메서드로 분리
+     */
+
+    private boolean isAdmin() {
+
+        return SecurityContextHolder.getContext().getAuthentication()
+                .getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"));
+    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/user/entity/User.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/user/entity/User.java
@@ -1,24 +1,16 @@
 package wercsmik.spaghetticodingclub.domain.user.entity;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import wercsmik.spaghetticodingclub.domain.assessment.entity.Assessment;
+import wercsmik.spaghetticodingclub.domain.team.entity.Team;
 import wercsmik.spaghetticodingclub.global.auditing.BaseTimeEntity;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -51,6 +43,10 @@ public class User extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "adminId", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Assessment> givenAssessments = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "teamId")
+    private Team team;
 
     @Builder
     private User(String username, String password, String email, String recommendEmail, UserRoleEnum role) {


### PR DESCRIPTION
**개요**
- 이 PR은 사용자가 팀을 생성할 수 있게 하는 기능을 추가합니다. 
- 이 기능은 특정 트랙 주차에 팀을 할당하여 사용자들이 그룹으로 활동할 수 있게 합니다.

**상세 내용**
- `Team` 엔티티에 `members` 필드를 추가하여 다대다 관계를 구현하였습니다.
- `TeamService`에서는 팀 생성 로직을 처리합니다. 사용자 목록을 받아 팀을 구성하고, 해당 팀을 데이터베이스에 저장합니다.

**테스트**
- Postman을 통해 API를 호출하여 실제 동작을 검증하였습니다.