### PR TITLE
feature/shcedule 팀(원)의 일정 전체 조회

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/controller/SchedulerController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/controller/SchedulerController.java
@@ -1,15 +1,19 @@
 package wercsmik.spaghetticodingclub.domain.schedule.controller;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import wercsmik.spaghetticodingclub.domain.schedule.dto.SchedulerCreationRequestDTO;
 import wercsmik.spaghetticodingclub.domain.schedule.dto.SchedulerCreationResponseDTO;
+import wercsmik.spaghetticodingclub.domain.schedule.dto.SchedulerResponseDTO;
 import wercsmik.spaghetticodingclub.domain.schedule.service.SchedulerService;
 import wercsmik.spaghetticodingclub.global.common.CommonResponse;
 import wercsmik.spaghetticodingclub.global.security.UserDetailsImpl;
@@ -30,5 +34,14 @@ public class SchedulerController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.of("일정 생성 성공", schedulerResponseDTO));
+    }
+
+    @GetMapping("/teams/{teamId}")
+    public ResponseEntity<CommonResponse<List<SchedulerResponseDTO>>> getTeamSchedules(
+            @PathVariable Long teamId) {
+
+        List<SchedulerResponseDTO> schedules = schedulerService.getTeamSchedules(teamId);
+
+        return ResponseEntity.ok(CommonResponse.of("팀내 모든 일정 조회 성공", schedules));
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/dto/SchedulerResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/dto/SchedulerResponseDTO.java
@@ -1,0 +1,33 @@
+package wercsmik.spaghetticodingclub.domain.schedule.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import wercsmik.spaghetticodingclub.domain.schedule.entity.Scheduler;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class SchedulerResponseDTO {
+
+    private Long schedulerId;
+
+    private Long userId;
+
+    private String title;
+
+    private LocalDateTime startTime;
+
+    private LocalDateTime endTime;
+
+    public static SchedulerResponseDTO of(Scheduler scheduler) {
+        return new SchedulerResponseDTO(
+                scheduler.getSchedulerId(),
+                scheduler.getUserId().getUserId(),
+                scheduler.getTitle(),
+                scheduler.getStartTime(),
+                scheduler.getEndTime()
+        );
+    }
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/repository/SchedulerRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/repository/SchedulerRepository.java
@@ -1,11 +1,15 @@
 package wercsmik.spaghetticodingclub.domain.schedule.repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import wercsmik.spaghetticodingclub.domain.schedule.entity.Scheduler;
 import wercsmik.spaghetticodingclub.domain.user.entity.User;
 
 public interface SchedulerRepository extends JpaRepository<Scheduler, Long> {
 
-    boolean existsByUserIdAndStartTimeLessThanAndEndTimeGreaterThan(User user, LocalDateTime endTime, LocalDateTime startTime);
+    boolean existsByUserIdAndStartTimeLessThanAndEndTimeGreaterThan(User user,
+            LocalDateTime endTime, LocalDateTime startTime);
+
+    List<Scheduler> findByUserIdIn(List<User> users);
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/service/SchedulerService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/service/SchedulerService.java
@@ -11,8 +11,10 @@ import wercsmik.spaghetticodingclub.domain.schedule.dto.SchedulerCreationRespons
 import wercsmik.spaghetticodingclub.domain.schedule.dto.SchedulerResponseDTO;
 import wercsmik.spaghetticodingclub.domain.schedule.entity.Scheduler;
 import wercsmik.spaghetticodingclub.domain.schedule.repository.SchedulerRepository;
+import wercsmik.spaghetticodingclub.domain.team.entity.Team;
 import wercsmik.spaghetticodingclub.domain.team.entity.TeamMember;
 import wercsmik.spaghetticodingclub.domain.team.repository.TeamMemberRepository;
+import wercsmik.spaghetticodingclub.domain.team.repository.TeamRepository;
 import wercsmik.spaghetticodingclub.domain.user.entity.User;
 import wercsmik.spaghetticodingclub.global.exception.CustomException;
 import wercsmik.spaghetticodingclub.global.exception.ErrorCode;
@@ -23,6 +25,7 @@ import wercsmik.spaghetticodingclub.global.security.UserDetailsImpl;
 public class SchedulerService {
 
     private final SchedulerRepository schedulerRepository;
+    private final TeamRepository teamRepository;
     private final TeamMemberRepository teamMemberRepository;
 
     @Transactional
@@ -63,15 +66,17 @@ public class SchedulerService {
     @Transactional(readOnly = true)
     public List<SchedulerResponseDTO> getTeamSchedules(Long teamId) {
 
-        // 팀Id 조회
-        List<TeamMember> teamTeamId = teamMemberRepository.findByTeam_TeamId(teamId);
+        Team team = teamRepository.findById(teamId) // 팀 조회
+                .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND));
 
-        if (teamTeamId.isEmpty()) {
-            throw new CustomException(ErrorCode.TEAM_NOT_FOUND);
+        List<TeamMember> teamMembers = teamMemberRepository.findByTeam_TeamId(teamId); // 팀 멤버 조회
+
+        if (teamMembers.isEmpty()) {
+            throw new CustomException(ErrorCode.TEAM_MEMBERS_NOT_FOUND);
         }
 
         // 팀 멤버들의 유저 리스트를 생성
-        List<User> users = teamTeamId.stream()
+        List<User> users = teamMembers.stream()
                 .map(TeamMember::getUser)
                 .collect(Collectors.toList());
 

--- a/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
@@ -31,8 +31,13 @@ public enum ErrorCode {
     // Scheduler
     SCHEDULE_OVERLAP(400, "일정이 겹칩니다."),
 
+    SCHEDULE_NOT_FOUND(404, "일정이 존재하지 않습니다."),
+
 
     // Team
+    TEAM_NOT_FOUND(400, "팀을 찾을 수 없습니다."),
+
+    TEAM_MEMBERS_NOT_FOUND(400, "팀원 들을 찾을 수 없습니다."),
 
 
     // Track


### PR DESCRIPTION
### 설명
이 PR은 팀(원)의 일정 전체 조회 기능을 추가하고, 팀내에 속한 모든 유저들의 모든 일정을 조회 하고자 하는것을 목표로 합니다. 

### 주요 변경 사항
- **팀(원)의 일정 전체 조회 로직 구현**: `SchedulerService`에 팀에 속한 멤버들을 조회하여 멤버들을 List 형태로 만든후 각 멤버들의 일정을 다시 List하여 가져오는 방식으로 정보를 조회할 수 있는 기능을 구현하였습니다.
- **예외 처리**: 정보 조회 할 시 팀의 유무, 팀원의 유무에 대하여 예외처리를 추가 하였습니다.

### 기대 효과
- **기능성 향상**: 사용자 및 관리자는 특정 팀에 대한 모든 일정 정보를 쉽게 조회할 수 있습니다.

#### 테스트 :
- 포스트맨(Postman)을 사용하여 API 엔드포인트에 대한 통합 테스트를 수행하였습니다.
- 불가능한 날짜 입력 시 API가 적절한 에러 코드와 메시지를 반환하는지 확인하였습니다.