### PR TITLE
feature/auth: 로그아웃 기능 구현 / tokenBlacklist 추가

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/controller/AuthController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/controller/AuthController.java
@@ -1,14 +1,19 @@
 package wercsmik.spaghetticodingclub.domain.auth.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import wercsmik.spaghetticodingclub.domain.auth.dto.EmailCheckRequestDTO;
 import wercsmik.spaghetticodingclub.domain.auth.dto.SignRequestDTO;
 import wercsmik.spaghetticodingclub.domain.auth.service.AuthService;
+import wercsmik.spaghetticodingclub.domain.auth.service.EmailService;
 import wercsmik.spaghetticodingclub.global.common.CommonResponse;
 
 @RestController
@@ -16,9 +21,11 @@ import wercsmik.spaghetticodingclub.global.common.CommonResponse;
 public class AuthController {
 
     private final AuthService authService;
+    private final EmailService emailService;
 
-    public AuthController(AuthService authService) {
+    public AuthController(AuthService authService, EmailService emailService) {
         this.authService = authService;
+        this.emailService = emailService;
     }
 
     @PostMapping("/signup")
@@ -29,5 +36,33 @@ public class AuthController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.of("회원가입 성공", null));
+    }
+
+    @PatchMapping("/logout")
+    public ResponseEntity<CommonResponse<Void>> logout(HttpServletRequest request) {
+
+        authService.logout(request);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.of("로그아웃 성공", null));
+    }
+
+    @PostMapping("/send-verification-email")
+    public ResponseEntity<CommonResponse<Void>> mailConfirm(
+            @RequestParam Long userId, @RequestBody EmailCheckRequestDTO emailCheckRequestDTO) {
+
+        emailService.sendVerificationEmail(userId, emailCheckRequestDTO.getEmail());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.of("인증 이메일 전송 성공", null));
+    }
+
+    @PostMapping("/verify-email")
+    public ResponseEntity<CommonResponse<Void>> verifyEmail(
+            @RequestBody EmailCheckRequestDTO requestDTO) {
+
+        emailService.verifyEmail(requestDTO.getVerificationCode(), requestDTO.getEmail());
+
+        return ResponseEntity.ok().body(CommonResponse.of("이메일 인증 성공", null));
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/AuthService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package wercsmik.spaghetticodingclub.domain.auth.service;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -12,6 +13,7 @@ import wercsmik.spaghetticodingclub.domain.user.entity.UserRoleEnum;
 import wercsmik.spaghetticodingclub.domain.user.repository.UserRepository;
 import wercsmik.spaghetticodingclub.global.exception.CustomException;
 import wercsmik.spaghetticodingclub.global.exception.ErrorCode;
+import wercsmik.spaghetticodingclub.global.jwt.JwtUtil;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +23,7 @@ public class AuthService {
     private final TrackRepository trackRepository;
     private final PasswordEncoder passwordEncoder;
     private final TrackParticipantsService trackParticipantsService;
+    private final JwtUtil jwtUtil;
 
     public void signup(SignRequestDTO signRequestDTO) {
 
@@ -69,5 +72,10 @@ public class AuthService {
         if (role == UserRoleEnum.USER) {
             trackParticipantsService.addParticipant(user.getUserId(), trackName);
         }
+    }
+
+    public void logout(HttpServletRequest request) {
+
+        jwtUtil.deleteToken(request);
     }
 }


### PR DESCRIPTION
### 설명
이 PR은 로그아웃 기능을 추가하고 토큰을 삭제하는 'deleteToken' 메서드를 'JwtUtil' 클래스에 구현함으로써 토큰을 무효화하여 이후 API 요청에 토큰이 작동하지 않게 하려는 목표를 지니고 있습니다.

### 주요 변경 사항
- **무효화된 토큰의 블랙리스트로 추가**: 로그아웃된 토큰을 블랙리스트로 관리합니다. 이는 HashSet과 같은 메모리 내 데이터 구조에 저장할 수 있으며, 영속성을 위해 데이터베이스에 저장할 수도 있습니다.
- **블랙리스트를 'validateToken' 메서드에서 확인**: 'validateToken' 메서드를 수정하여 토큰이 블랙리스트에 있는지 확인합니다. 블랙리스트에 있으면 토큰을 유효하지 않은 것으로 간주합니다.

### 기대 효과
- **블랙리스트를 통한 토큰의 무효화**: 블랙리스트를 데이터베이스에 저장하여 무효화된 토큰을 관리하며 해당토큰은 더이상 유효하지 않으므로 다른 API를 작동할 수 없습니다.