### PR TITLE
feat: 팀 생성 시 여러개의 팀 동시에 생성

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/team/controller/TeamController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/team/controller/TeamController.java
@@ -5,10 +5,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-import wercsmik.spaghetticodingclub.domain.team.dto.TeamCreationRequestDTO;
+import wercsmik.spaghetticodingclub.domain.team.dto.MultipleTeamCreationRequestDTO;
 import wercsmik.spaghetticodingclub.domain.team.dto.TeamCreationResponseDTO;
 import wercsmik.spaghetticodingclub.domain.team.service.TeamService;
 import wercsmik.spaghetticodingclub.global.common.CommonResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/tracks/{trackId}/trackWeeks/{trackWeekId}/teams")
@@ -19,15 +21,15 @@ public class TeamController {
 
     @PostMapping
     @PreAuthorize("hasAuthority('ROLE_ADMIN')")
-    public ResponseEntity<CommonResponse<TeamCreationResponseDTO>> createTeam(
+    public ResponseEntity<CommonResponse<List<TeamCreationResponseDTO>>> createTeams(
             @PathVariable Long trackId,
             @PathVariable Long trackWeekId,
-            @RequestBody TeamCreationRequestDTO requestDTO) {
+            @RequestBody MultipleTeamCreationRequestDTO requestDTO) {
 
-        TeamCreationResponseDTO responseDTO = teamService.createTeam(trackId, trackWeekId, requestDTO);
+        List<TeamCreationResponseDTO> createdTeams = teamService.createTeams(trackId, trackWeekId, requestDTO);
 
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(CommonResponse.of("팀 생성 성공", responseDTO));
+                .body(CommonResponse.of("팀 생성 성공", createdTeams));
     }
 
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/team/dto/MultipleTeamCreationRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/team/dto/MultipleTeamCreationRequestDTO.java
@@ -1,0 +1,17 @@
+package wercsmik.spaghetticodingclub.domain.team.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MultipleTeamCreationRequestDTO {
+
+    private List<TeamCreationRequestDTO> teams;
+}


### PR DESCRIPTION
## 요구사항
- 여러 팀을 동시에 생성할 수 있어야 합니다.
- 각 팀에는 여러 명의 멤버를 포함할 수 있어야 합니다.
- 관리자 권한을 가진 사용자만이 팀을 생성할 수 있어야 합니다.

## 구현 항목
- [x] 여러 팀을 동시에 생성할 수 있는 엔드포인트 추가 (`/tracks/{trackId}/trackWeeks/{trackWeekId}/teams/batch`).
- [x] `MultipleTeamCreationRequestDTO`와 `TeamCreationRequestDTO` 클래스 추가.
- [x] 팀 생성 로직을 처리하는 `TeamService` 메서드 수정.
- [x] 요청에 포함된 여러 팀과 그 멤버들을 데이터베이스에 저장하는 기능 구현.
- [x] 각 팀의 생성된 멤버 정보를 응답으로 반환.

## 기대 효과
- 관리자가 여러 팀을 한 번의 요청으로 생성할 수 있어 작업 효율성이 향상됩니다.
- 팀 생성 시 각 팀에 포함된 멤버들의 정보도 함께 반환되어 프론트엔드에서의 추가적인 데이터를 요청할 필요가 없습니다.