### PR TITLE
feature/shcedule 일정 수정 

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/controller/SchedulerController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/controller/SchedulerController.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import wercsmik.spaghetticodingclub.domain.schedule.dto.SchedulerCreationRequestDTO;
 import wercsmik.spaghetticodingclub.domain.schedule.dto.SchedulerCreationResponseDTO;
 import wercsmik.spaghetticodingclub.domain.schedule.dto.SchedulerResponseDTO;
+import wercsmik.spaghetticodingclub.domain.schedule.dto.SchedulerUpdateRequestDTO;
 import wercsmik.spaghetticodingclub.domain.schedule.service.SchedulerService;
 import wercsmik.spaghetticodingclub.global.common.CommonResponse;
 import wercsmik.spaghetticodingclub.global.security.UserDetailsImpl;
@@ -60,5 +62,16 @@ public class SchedulerController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of("특정 날짜 범위 내 팀내 일정 조회 성공", schedules));
+    }
+
+    @PutMapping("/{schedulerId}")
+    public ResponseEntity<CommonResponse<SchedulerResponseDTO>> updateSchedule(
+            @PathVariable Long schedulerId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody SchedulerUpdateRequestDTO requestDTO) {
+
+        SchedulerResponseDTO schedulerResponseDTO = schedulerService.updateSchedule(schedulerId, userDetails, requestDTO);
+
+        return ResponseEntity.ok(CommonResponse.of("일정 수정 성공", schedulerResponseDTO));
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/controller/SchedulerController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/controller/SchedulerController.java
@@ -72,6 +72,7 @@ public class SchedulerController {
 
         SchedulerResponseDTO schedulerResponseDTO = schedulerService.updateSchedule(schedulerId, userDetails, requestDTO);
 
-        return ResponseEntity.ok(CommonResponse.of("일정 수정 성공", schedulerResponseDTO));
+        return ResponseEntity.status(HttpStatus.OK).
+                body(CommonResponse.of("일정 수정 성공", schedulerResponseDTO));
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/dto/SchedulerUpdateRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/dto/SchedulerUpdateRequestDTO.java
@@ -1,0 +1,19 @@
+package wercsmik.spaghetticodingclub.domain.schedule.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SchedulerUpdateRequestDTO {
+
+    private String title;
+
+    private LocalDateTime startTime;
+
+    private LocalDateTime endTime;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/entity/Scheduler.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/entity/Scheduler.java
@@ -39,4 +39,16 @@ public class Scheduler extends BaseTimeEntity {
 
     @Column(nullable = false)
     private LocalDateTime endTime;
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/repository/SchedulerRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/repository/SchedulerRepository.java
@@ -17,4 +17,7 @@ public interface SchedulerRepository extends JpaRepository<Scheduler, Long> {
 
     @Query("SELECT s FROM Scheduler s WHERE s.userId IN :users AND (s.startTime >= :startDate AND s.startTime <= :endDate OR s.endTime >= :startDate AND s.endTime <= :endDate OR s.startTime < :startDate AND s.endTime > :endDate)")
     List<Scheduler> findByUserIdInAndDateRange(@Param("users") List<User> users, @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
+    @Query("SELECT COUNT(s) > 0 FROM Scheduler s WHERE s.userId = :user AND s.schedulerId != :schedulerId AND (s.startTime < :endTime AND s.endTime > :startTime)")
+    boolean existsByUserIdAndSchedulerIdNotAndTimeRangeOverlap(@Param("user") User user, @Param("schedulerId") Long schedulerId, @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
 }


### PR DESCRIPTION
### 설명
이 PR은 일정 수정 기능을 추가하고, 일정을 작성한 본인만 일정을 수정할 수 있으며 일정을 수정할 경우 다양한 경우( 제목만입력, 제목과 시작시간입력, 제목과 종료시간 입력, 제목과 시작 종료시간 입력)에도 변경이 가능하도록 하여야 하며 수정하고자 하는 일정의 시간이 다른 일정과 시간이 겹쳐서는 안되도록 하여야 합니다.

### 주요 변경 사항
- **사용자가 해당 일정을 소유하고 있는지 확인 추가**
- **StartTime 또는 EndTime이 업데이트되는지 여부 확인** : 만약 내용이 없을 경우 DB를 반영하여 저장된 기존 시간으로 
- 응답 예시 1
   ```json
   {
    "title": "3개다 수정하기",
    "startDate": "2024-06-10T00:00:00",
    "endDate": "2024-06-14T23:59:59"
   }
   ```
- 결과값:
    ```json
   {
    "message": "일정 수정 성공",
    "payload": {
        "schedulerId": 8,
        "userId": 2,
        "title": "3개다 수정하기",
        "startTime": "2024-06-12T00:00:00",
        "endTime": "2024-06-17T06:30:00"
       }
   }
    ```
- 응답 예시 2
   ```json
   {
    "title": "제목만 수정",
   }
   ```
- 결과값:
    ```json
   {
    "message": "일정 수정 성공",
    "payload": {
        "schedulerId": 8,
        "userId": 2,
        "title": "제목만 수정",
        "startTime": "2024-06-12T00:00:00",
        "endTime": "2024-06-17T06:30:00"
       }
   }
    ```
- 응답 예시 3
   ```json
   {
    "title": "제목, 시작시간 수정",
   }
   ```
- 결과값:
    ```json
   {
    "message": "일정 수정 성공",
    "payload": {
        "schedulerId": 8,
        "userId": 2,
        "title": "제목, 시작시간 수정",
        "startTime": "2024-06-15T10:00:00",
        "endTime": "2024-06-17T06:30:00"
       }
   }
    ```
    
- **예외 처리**: 일정 수정할 경우 본인확인, 수정하려는 일정유무확인, 수정하려는 일정이 다른일정과 시간이 겹치는것 에대한 유무확인 등을 예외처리를 추가 하였습니다.

### 기대 효과
- **기능성 향상**: 사용자 는 기존에 작성했었던 일정을 다시 내용과 시간대로 원하는 대로 수정할 수 있습니다..

#### 테스트 :
- 포스트맨(Postman)을 사용하여 API 엔드포인트에 대한 통합 테스트를 수행하였습니다.
- 불가능한 날짜 입력 시 API가 적절한 에러 코드와 메시지를 반환하는지 확인하였습니다.- 