### PR TITLE
feat: 비호감도 생성

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/controller/UnlikeController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/controller/UnlikeController.java
@@ -1,4 +1,32 @@
 package wercsmik.spaghetticodingclub.domain.unlike.controller;
 
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import wercsmik.spaghetticodingclub.domain.unlike.dto.UnlikeCreationRequestDTO;
+import wercsmik.spaghetticodingclub.domain.unlike.dto.UnlikeCreationResponseDTO;
+import wercsmik.spaghetticodingclub.domain.unlike.service.UnlikeService;
+import wercsmik.spaghetticodingclub.global.common.CommonResponse;
+
+@AllArgsConstructor
+@RestController
+@RequestMapping("/unlike")
 public class UnlikeController {
+
+    private final UnlikeService unlikeService;
+
+    @PostMapping
+    public ResponseEntity<CommonResponse<UnlikeCreationResponseDTO>> createUnlike(
+            @RequestBody UnlikeCreationRequestDTO requestDTO) {
+
+        UnlikeCreationResponseDTO unlike = unlikeService.createUnlike(requestDTO);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CommonResponse.of("비호감도 생성 성공", unlike));
+    }
+
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/dto/UnlikeCreationRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/dto/UnlikeCreationRequestDTO.java
@@ -1,0 +1,15 @@
+package wercsmik.spaghetticodingclub.domain.unlike.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UnlikeCreationRequestDTO {
+
+    private Long senderUserId;
+
+    private Long receiverUserId;
+
+    private Long teamId;
+
+    private String cause;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/dto/UnlikeCreationResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/dto/UnlikeCreationResponseDTO.java
@@ -1,0 +1,27 @@
+package wercsmik.spaghetticodingclub.domain.unlike.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UnlikeCreationResponseDTO {
+
+    private Long unlikeId;
+
+    private Long senderUserId;
+
+    private Long receiverUserId;
+
+    private Long teamId;
+
+    private String cause;
+
+    public UnlikeCreationResponseDTO(Long unlikeId, Long senderUserId, Long teamId, Long receiverUserId, String cause) {
+        this.unlikeId = unlikeId;
+        this.senderUserId = senderUserId;
+        this.receiverUserId = receiverUserId;
+        this.teamId = teamId;
+        this.cause = cause;
+    }
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/dto/UnlikeCreationResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/dto/UnlikeCreationResponseDTO.java
@@ -17,7 +17,7 @@ public class UnlikeCreationResponseDTO {
 
     private String cause;
 
-    public UnlikeCreationResponseDTO(Long unlikeId, Long senderUserId, Long teamId, Long receiverUserId, String cause) {
+    public UnlikeCreationResponseDTO(Long unlikeId, Long senderUserId, Long receiverUserId, Long teamId, String cause) {
         this.unlikeId = unlikeId;
         this.senderUserId = senderUserId;
         this.receiverUserId = receiverUserId;

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/dto/UnlikeRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/dto/UnlikeRequestDTO.java
@@ -1,4 +1,0 @@
-package wercsmik.spaghetticodingclub.domain.unlike.dto;
-
-public class UnlikeRequestDTO {
-}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/dto/UnlikeResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/dto/UnlikeResponseDTO.java
@@ -1,4 +1,0 @@
-package wercsmik.spaghetticodingclub.domain.unlike.dto;
-
-public class UnlikeResponseDTO {
-}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/entity/Unlike.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/entity/Unlike.java
@@ -1,4 +1,39 @@
 package wercsmik.spaghetticodingclub.domain.unlike.entity;
 
+import jakarta.persistence.*;
+import lombok.*;
+import wercsmik.spaghetticodingclub.domain.team.entity.Team;
+import wercsmik.spaghetticodingclub.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Table(name = "Unlikes")
 public class Unlike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long unlikeId;
+
+    @ManyToOne
+    @JoinColumn(name = "senderUserId", nullable = false)
+    private User sender;
+
+    @ManyToOne
+    @JoinColumn(name = "receiverUserId", nullable = false)
+    private User receiver;
+
+    @ManyToOne
+    @JoinColumn(name = "teamId", nullable = false)
+    private Team team;
+
+    @Column(name = "cause", nullable = false, columnDefinition = "TEXT")
+    private String cause;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/repository/UnlikeRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/repository/UnlikeRepository.java
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import wercsmik.spaghetticodingclub.domain.unlike.entity.Unlike;
 
 public interface UnlikeRepository extends JpaRepository<Unlike, Long> {
+
+    boolean existsBySenderUserIdAndTeam_TeamId(Long senderUserId, Long teamId);
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/repository/UnlikeRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/repository/UnlikeRepository.java
@@ -1,4 +1,7 @@
 package wercsmik.spaghetticodingclub.domain.unlike.repository;
 
-public interface UnlikeRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import wercsmik.spaghetticodingclub.domain.unlike.entity.Unlike;
+
+public interface UnlikeRepository extends JpaRepository<Unlike, Long> {
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/service/UnlikeService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/unlike/service/UnlikeService.java
@@ -1,4 +1,70 @@
 package wercsmik.spaghetticodingclub.domain.unlike.service;
 
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import wercsmik.spaghetticodingclub.domain.team.entity.TeamMember;
+import wercsmik.spaghetticodingclub.domain.team.repository.TeamMemberRepository;
+import wercsmik.spaghetticodingclub.domain.unlike.dto.UnlikeCreationRequestDTO;
+import wercsmik.spaghetticodingclub.domain.unlike.dto.UnlikeCreationResponseDTO;
+import wercsmik.spaghetticodingclub.domain.unlike.entity.Unlike;
+import wercsmik.spaghetticodingclub.domain.unlike.repository.UnlikeRepository;
+import wercsmik.spaghetticodingclub.domain.user.entity.User;
+import wercsmik.spaghetticodingclub.domain.user.repository.UserRepository;
+import wercsmik.spaghetticodingclub.global.exception.CustomException;
+import wercsmik.spaghetticodingclub.global.exception.ErrorCode;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
 public class UnlikeService {
+
+    private final UnlikeRepository unlikeRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public UnlikeCreationResponseDTO createUnlike(UnlikeCreationRequestDTO unlikeRequestDto) {
+        validateTeamMembers(unlikeRequestDto.getSenderUserId(), unlikeRequestDto.getReceiverUserId(), unlikeRequestDto.getTeamId());
+
+        User sender = userRepository.findById(unlikeRequestDto.getSenderUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User receiver = userRepository.findById(unlikeRequestDto.getReceiverUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        LocalDateTime now = LocalDateTime.now();
+
+        Unlike unlike = Unlike.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .team(teamMemberRepository.findByTeam_TeamId(unlikeRequestDto.getTeamId()).stream()
+                        .findFirst()
+                        .map(TeamMember::getTeam)
+                        .orElseThrow(() -> new CustomException(ErrorCode.TEAM_NOT_FOUND)))
+                .cause(unlikeRequestDto.getCause())
+                .createdAt(now)
+                .build();
+
+        unlikeRepository.save(unlike);
+
+        return new UnlikeCreationResponseDTO(unlike.getUnlikeId(), sender.getUserId(), receiver.getUserId(), unlikeRequestDto.getTeamId(), unlike.getCause());
+    }
+
+    /*
+        공통 로직을
+        메서드로 분리
+     */
+
+    private void validateTeamMembers(Long senderUserId, Long receiverUserId, Long teamId) {
+        List<Long> memberUserIds = teamMemberRepository.findByTeam_TeamId(teamId)
+                .stream()
+                .map(tm -> tm.getUser().getUserId())
+                .toList();
+
+        if (!memberUserIds.contains(senderUserId) || !memberUserIds.contains(receiverUserId)) {
+            throw new CustomException(ErrorCode.TEAM_MEMBERS_NOT_FOUND);
+        }
+    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
@@ -67,7 +67,7 @@ public enum ErrorCode {
 
 
     // Unlike
-
+    UNLIKE_ALREADY_EXISTS(400, "이미 비호감도를 생성하셨습니다."),
 
     // Jwt
     INVALID_JWT_SIGNATURE(401, "유효하지 않는 JWT 서명 입니다."),


### PR DESCRIPTION
팀 내에서 비호감도 기록을 생성할 수 있는 기능을 도입합니다.
 각 팀원은 팀 내 다른 팀원에게 한 번만 비호감도를 줄 수 있어, 각 멤버의 피드백이 중복 없이 등록될 수 있습니다.

**기술적 변경 사항:**
1. **엔티티 변경 사항:**
   - 발신자, 수신자, 팀, 원인, 타임스탬프를 필드로 가지는 `Unlike` 엔티티 추가.
2. **리포지토리 변경 사항:**
   - `senderUserId`와 `teamId`로 비호감도 존재 여부를 확인하는 메소드를 `UnlikeRepository`에 추가.
3. **서비스 레이어:**
   - 새로운 비호감도를 생성하는 로직을 처리하는 `UnlikeService` 내에 `createUnlike` 메소드 추가.
   - 발신자와 수신자가 팀의 일원임을 확인하고 동일 팀 내에서 발신자가 이미 비호감도를 주지 않았는지 검증하는 유효성 검사 포함.
4. **컨트롤러 레이어:**
   - 비호감도 생성과 관련된 HTTP 요청을 관리하는 `UnlikeController` 생성.

**테스트 방법:**
1. 비호감도 생성 엔드포인트 `/unlike`로 이동합니다.
2. `senderUserId`, `receiverUserId`, `teamId`, `cause`를 포함하는 JSON 본문을 제공합니다.
3. 요청이 성공 응답을 반환하고 데이터베이스에 비호감도 기록이 생성되는지 확인합니다.
4. 동일 팀에 대해 중복 비호감도를 생성하여 유효성 검증이 제대로 작동하는지 확인합니다.

**문서화:**
- 새 비호감도 생성 엔드포인트의 세부사항과 예제를 포함하여 API 문서를 업데이트했습니다.