### PR TITLE
feature/shcedule: 일정 삭제 

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/controller/SchedulerController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/controller/SchedulerController.java
@@ -7,6 +7,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -74,5 +75,16 @@ public class SchedulerController {
 
         return ResponseEntity.status(HttpStatus.OK).
                 body(CommonResponse.of("일정 수정 성공", schedulerResponseDTO));
+    }
+
+    @DeleteMapping("/{schedulerId}")
+    public ResponseEntity<CommonResponse<SchedulerResponseDTO>> deleteSchedule(
+            @PathVariable Long schedulerId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        schedulerService.deleteSchedule(schedulerId, userDetails);
+
+        return ResponseEntity.status(HttpStatus.OK).
+                body(CommonResponse.of("일정 삭제 성공", null));
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/controller/SchedulerController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/controller/SchedulerController.java
@@ -72,6 +72,7 @@ public class SchedulerController {
 
         SchedulerResponseDTO schedulerResponseDTO = schedulerService.updateSchedule(schedulerId, userDetails, requestDTO);
 
-        return ResponseEntity.ok(CommonResponse.of("일정 수정 성공", schedulerResponseDTO));
+        return ResponseEntity.status(HttpStatus.OK).
+                body(CommonResponse.of("일정 수정 성공", schedulerResponseDTO));
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/service/SchedulerService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/schedule/service/SchedulerService.java
@@ -167,4 +167,18 @@ public class SchedulerService {
 
         return SchedulerResponseDTO.of(updatedScheduler);
     }
+
+    @Transactional
+    public void deleteSchedule(Long schedulerId, UserDetailsImpl userDetails) {
+
+        Scheduler schedule = schedulerRepository.findById(schedulerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SCHEDULE_NOT_FOUND));
+
+        // 사용자가 해당 일정을 소유하고 있는지 확인
+        if (!schedule.getUserId().getUserId().equals(userDetails.getUser().getUserId())) {
+            throw new CustomException(ErrorCode.NO_AUTHENTICATION);
+        }
+
+        schedulerRepository.delete(schedule);
+    }
 }


### PR DESCRIPTION
이 PR은 일정을 삭제할 수 있는 기능을 도입합니다.
오로지 본인이 생성 했던 일정만 삭제 가능하며 본인 외에 다른 사용자가 생성했던 일정은 삭제 할 수 없습니다.

**기술적 변경 사항:**
1. **SchceduleController:**
   - 일정 삭제와 관련된 HTTP 요청을 관리하는 API 추가.
2. **SchceduleService:**
   - 일정 삭제를 위해 삭제하려는 일정 존재여부, 본인이 작성했던 일정인지에 대한 여부 확인 로직 추가


#### 테스트 :
- 포스트맨(Postman)을 사용하여 API 테스트를 수행하였습니다.
- 존재하지않는 일정일 경우, 삭제하려는 일정이 본인이 아닌경우 에 대한 예외처리를 확인하였습니다.- 
