### PR TITLE
feature/auth: 유저 탈퇴 기능 구현

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/controller/AuthController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/controller/AuthController.java
@@ -3,13 +3,17 @@ package wercsmik.spaghetticodingclub.domain.auth.controller;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import wercsmik.spaghetticodingclub.domain.auth.dto.DeleteRequestDTO;
 import wercsmik.spaghetticodingclub.domain.auth.dto.SignRequestDTO;
 import wercsmik.spaghetticodingclub.domain.auth.service.AuthService;
 import wercsmik.spaghetticodingclub.global.common.CommonResponse;
+import wercsmik.spaghetticodingclub.global.security.UserDetailsImpl;
 
 @RestController
 @RequestMapping("/api/auths")
@@ -29,5 +33,16 @@ public class AuthController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.of("회원가입 성공", null));
+    }
+
+    @DeleteMapping("/withDraw")
+    public ResponseEntity<CommonResponse<Void>> deleteUser(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Valid @RequestBody DeleteRequestDTO deleteRequestDTO) {
+
+        authService.deleteUser(userDetails, deleteRequestDTO);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.of("유저 삭제 성공", null));
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/controller/AuthController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/controller/AuthController.java
@@ -36,11 +36,11 @@ public class AuthController {
     }
 
     @DeleteMapping("/withDraw")
-    public ResponseEntity<CommonResponse<Void>> deleteUser(
+    public ResponseEntity<CommonResponse<Void>> withDrawUser(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @Valid @RequestBody DeleteRequestDTO deleteRequestDTO) {
 
-        authService.deleteUser(userDetails, deleteRequestDTO);
+        authService.withDrawUser(userDetails, deleteRequestDTO);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.of("유저 삭제 성공", null));

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/dto/DeleteRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/dto/DeleteRequestDTO.java
@@ -1,0 +1,11 @@
+package wercsmik.spaghetticodingclub.domain.auth.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+@Getter
+public class DeleteRequestDTO {
+
+    @NotEmpty(message = "비밀번호는 필수 입력 값입니다.")
+    private String password;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/AuthService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/AuthService.java
@@ -75,7 +75,7 @@ public class AuthService {
     }
 
     @Transactional
-    public void deleteUser(UserDetailsImpl userDetails, DeleteRequestDTO deleteRequestDTO) {
+    public void withDrawUser(UserDetailsImpl userDetails, DeleteRequestDTO deleteRequestDTO) {
         Long userId = userDetails.getUser().getUserId();
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/AuthService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/AuthService.java
@@ -4,6 +4,8 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import wercsmik.spaghetticodingclub.domain.auth.dto.DeleteRequestDTO;
 import wercsmik.spaghetticodingclub.domain.auth.dto.SignRequestDTO;
 import wercsmik.spaghetticodingclub.domain.track.repository.TrackRepository;
 import wercsmik.spaghetticodingclub.domain.track.service.TrackParticipantsService;
@@ -12,6 +14,7 @@ import wercsmik.spaghetticodingclub.domain.user.entity.UserRoleEnum;
 import wercsmik.spaghetticodingclub.domain.user.repository.UserRepository;
 import wercsmik.spaghetticodingclub.global.exception.CustomException;
 import wercsmik.spaghetticodingclub.global.exception.ErrorCode;
+import wercsmik.spaghetticodingclub.global.security.UserDetailsImpl;
 
 @Service
 @RequiredArgsConstructor
@@ -69,5 +72,23 @@ public class AuthService {
         if (role == UserRoleEnum.USER) {
             trackParticipantsService.addParticipant(user.getUserId(), trackName);
         }
+    }
+
+    @Transactional
+    public void deleteUser(UserDetailsImpl userDetails, DeleteRequestDTO deleteRequestDTO) {
+        Long userId = userDetails.getUser().getUserId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 비밀번호 확인
+        if (!passwordEncoder.matches(deleteRequestDTO.getPassword(), user.getPassword())) {
+            throw new CustomException(ErrorCode.PASSWORD_MISMATCH_EXCEPTION);
+        }
+
+        // 트랙 참여자 목록에서 제거
+        trackParticipantsService.removeParticipant(userId);
+
+        // 유저 삭제
+        userRepository.delete(user);
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/track/service/TrackParticipantsService.java
@@ -97,4 +97,10 @@ public class TrackParticipantsService {
                 .updatedTrackName(newTrack.getTrackName())
                 .build();
     }
+
+    @Transactional
+    public void removeParticipant(Long userId) {
+        List<TrackParticipants> participants = trackParticipantsRepository.findByUserUserId(userId);
+        trackParticipantsRepository.deleteAll(participants);
+    }
 }


### PR DESCRIPTION
### 설명
이 PR은 유저 탈퇴 기능을 추가하며 탈퇴를 할 경우 오로지 사용자 본인만 탈퇴가 가능하며, 또한 탈퇴시 비밀번호를 입력함으로서 본인이 정말로 탈퇴하는것이 맞는지에대해서 다시한번 확인 과정을 거치는 구조로 구현 되었습니다.

### 주요 변경 사항
- **DeleteRequestDTO 추가**: 탈퇴 시 비밀번호를 입력함으로서 본인 확인과 혹시나 모를 실수로 인해 탈퇴할 가능성을 없애도록 합니다.


### 기대 효과
- **실수로 인한 탈퇴 경우 방지**: 탈퇴시 비밀번호 입력으로 실수로 인해 탈퇴할 경우를 방지하면서 본인만 탈퇴가 가능합니다.