### PR TITLE
fix: 유저 로그인 성공 응답에 trackId 값 추가

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/dto/LoginResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/dto/LoginResponseDTO.java
@@ -17,12 +17,13 @@ public class LoginResponseDTO {
 
     private String track;
 
+    private Long trackId;
+
     private UserRoleEnum role;
 
     private String recommendEmail;
 
-    public LoginResponseDTO(User user, String trackName) {
-
+    public LoginResponseDTO(User user, String trackName, Long trackId) {
         this.userId = user.getUserId();
 
         this.username = user.getUsername();
@@ -30,6 +31,8 @@ public class LoginResponseDTO {
         this.email = user.getEmail();
 
         this.track = trackName;
+
+        this.trackId = trackId;
 
         this.role = user.getRole();
 

--- a/src/main/java/wercsmik/spaghetticodingclub/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/jwt/JwtAuthenticationFilter.java
@@ -80,9 +80,12 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         List<TrackParticipants> trackParticipants = trackParticipantsRepository.findByUserUserId(user.getUserId());
         String trackName = trackParticipants.stream().findFirst()
                 .map(participant -> participant.getTrack().getTrackName())
-                .orElse("참여된 트랙 없음"); // 사용자가 어떤 트랙에도 참여하지 않았다면 기본값 설정
+                .orElse("참여된 트랙 없음");
+        Long trackId = trackParticipants.stream().findFirst()
+                .map(participant -> participant.getTrack().getTrackId())
+                .orElse(null); // 트랙 ID 가져오기
 
-        LoginResponseDTO loginResponseDTO = new LoginResponseDTO(user.getUserId(), user.getUsername(), user.getEmail(), trackName, user.getRole(), user.getRecommendEmail());
+        LoginResponseDTO loginResponseDTO = new LoginResponseDTO(user.getUserId(), user.getUsername(), user.getEmail(), trackName, trackId, user.getRole(), user.getRecommendEmail());
 
         // CommonResponse 객체 생성
         CommonResponse<LoginResponseDTO> commonResponse = CommonResponse.of("로그인 성공", loginResponseDTO);


### PR DESCRIPTION
해당 PR은 유저 로그인시 Long trackId 값을 가져오기 위하여 수정한 내용입니다.