### PR TITLE
feature: 본인 프로필 조회 API구현 / 공통로직 정리

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/user/controller/UserController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/user/controller/UserController.java
@@ -24,12 +24,21 @@ public class UserController {
 
     private final UserService userService;
 
+    @GetMapping
+    public ResponseEntity<CommonResponse<ProfileResponseDTO>> getMyProfile(
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        ProfileResponseDTO responseDTO = userService.getMyProfile(userDetails);
+
+        return ResponseEntity.ok().body(CommonResponse.of("본인 프로필 조회 성공", responseDTO));
+    }
+
     @GetMapping("/{userId}")
-    public ResponseEntity<CommonResponse<ProfileResponseDTO>> getProfile(@PathVariable Long userId) {
+    public ResponseEntity<CommonResponse<ProfileResponseDTO>> getUserProfile(@PathVariable Long userId) {
 
-        ProfileResponseDTO responseDTO = userService.getProfile(userId);
+        ProfileResponseDTO responseDTO = userService.getUserProfile(userId);
 
-        return ResponseEntity.ok().body(CommonResponse.of("프로필 조회 성공", responseDTO));
+        return ResponseEntity.ok().body(CommonResponse.of("특정 유저 프로필 조회 성공", responseDTO));
     }
 
     @PatchMapping("/{userId}/password")

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/user/dto/ProfileResponseDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/user/dto/ProfileResponseDTO.java
@@ -22,14 +22,18 @@ public class ProfileResponseDTO {
 
     private UserRoleEnum role;
 
+    private Long trackId;
+
     private String trackName;
+
+    private Long currentTrackWeekId;
 
     private List<TrackWeekCreationResponseDTO> trackWeeks;
 
     private AssessmentResponseDTO assessment;
 
 
-    public ProfileResponseDTO(User user, String trackName, List<TrackWeekCreationResponseDTO> trackWeeks, AssessmentResponseDTO assessment) {
+    public ProfileResponseDTO(User user, Long trackId, String trackName, Long currentTrackWeekId, List<TrackWeekCreationResponseDTO> trackWeeks, AssessmentResponseDTO assessment) {
 
         this.userId = user.getUserId();
 
@@ -41,7 +45,11 @@ public class ProfileResponseDTO {
 
         this.role = user.getRole();
 
+        this.trackId = trackId;
+
         this.trackName = trackName;
+
+        this.currentTrackWeekId = currentTrackWeekId;
 
         this.trackWeeks = trackWeeks;
 


### PR DESCRIPTION
### 설명
이 PR은 로그인한 사용자가 본인 프로필 조회 기능을 추가하였으며, 응답값에서 trackId 와 현재시간을 기준으로 속해있는 trackWeekId가 나오도록 반영하였으며 특정 유저 프로필 조회 기능과 중복된코드를 공통로직으로 정리함으로서 코드의 가독성과 유지보수성을 높이는데 목적이 있습니다.

### 주요 변경 사항
- **본인 프로필 조회 로직 구현**: 로그인한 사용자가 본인의 정보만 가져올 수 있도록 API를 추가 하였습니다.
- **ProfileResponseDTO 변경**: 기존 응답값에서 유저가 속해있는 trackId와 현재 시간을 기준으로 속해있는 trackWeekId를 가져오도록 반영하였습니다..
- **공통로직 정리**: 특정 유저 프로필 조회 기능과 중복코드 부분이 많이 겹침으로 중복되는 부분은 createProfileResponseDTO 메소드 로 공통로직으로 정리하였습니다.

### 기대 효과
- **코드의 가독성과 유지보수성 향상**
- **사용자 본인의 모든정보를 한번가져올 수 있게됨**

#### 테스트 :
- 포스트맨(Postman)을 사용하여 API 엔드포인트에 대한 통합 테스트를 수행하였습니다.