### PR TITLE
bugfix: 유저 삭제시 생기던 403 오류 수정

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/user/entity/User.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/user/entity/User.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import wercsmik.spaghetticodingclub.domain.assessment.entity.Assessment;
 import wercsmik.spaghetticodingclub.domain.team.entity.Team;
+import wercsmik.spaghetticodingclub.domain.team.entity.TeamMember;
 import wercsmik.spaghetticodingclub.global.auditing.BaseTimeEntity;
 
 import java.util.ArrayList;
@@ -43,6 +44,9 @@ public class User extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "adminId", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Assessment> givenAssessments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<TeamMember> teamMembers = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "teamId")


### PR DESCRIPTION
삭제하려는 유저가 TeamMember에 속해있을 경우 외래키 값으로 인해서 삭제 처리가 되지않음

이에 대해서 User 엔티티에서 TeamMember와의 양방향 관계를 설정하고 cascade = CascadeType.ALL 및 orphanRemoval = true를 추가함으로서 같이 삭제 될수 있도록 처리함.