### PR TITLE
feature/user 사용자 이름 변경 기능 구현

### DIFF
--- a/src/main/java/wercsmik/spaghetticodingclub/domain/user/controller/UserController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package wercsmik.spaghetticodingclub.domain.user.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import wercsmik.spaghetticodingclub.domain.user.dto.ProfileResponseDTO;
+import wercsmik.spaghetticodingclub.domain.user.dto.UpdateUserNameRequestDTO;
 import wercsmik.spaghetticodingclub.domain.user.dto.UpdateUserPasswordRequestDTO;
 import wercsmik.spaghetticodingclub.domain.user.entity.User;
 import wercsmik.spaghetticodingclub.domain.user.service.UserService;
@@ -53,4 +55,16 @@ public class UserController {
         return ResponseEntity.ok().body(CommonResponse.of("비밀번호 수정 성공", null));
     }
 
+    @PatchMapping("/{userId}/username")
+    @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+    public ResponseEntity<CommonResponse<Void>> updateName(
+            @PathVariable Long userId,
+            @Valid @RequestBody UpdateUserNameRequestDTO requestDTO,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        User loginUser = userDetails.getUser();
+        userService.updateUserName(userId, requestDTO, loginUser);
+
+        return ResponseEntity.ok().body(CommonResponse.of("사용자 이름 변경 성공", null));
+    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/user/dto/UpdateUserNameRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/user/dto/UpdateUserNameRequestDTO.java
@@ -1,0 +1,9 @@
+package wercsmik.spaghetticodingclub.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateUserNameRequestDTO {
+
+    private String username;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/user/entity/User.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/user/entity/User.java
@@ -68,4 +68,8 @@ public class User extends BaseTimeEntity {
     public void setRole(UserRoleEnum role) {
         this.role = role;
     }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/user/service/UserService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/user/service/UserService.java
@@ -15,8 +15,10 @@ import wercsmik.spaghetticodingclub.domain.track.entity.TrackParticipants;
 import wercsmik.spaghetticodingclub.domain.track.repository.TrackParticipantsRepository;
 import wercsmik.spaghetticodingclub.domain.track.repository.TrackWeekRepository;
 import wercsmik.spaghetticodingclub.domain.user.dto.ProfileResponseDTO;
+import wercsmik.spaghetticodingclub.domain.user.dto.UpdateUserNameRequestDTO;
 import wercsmik.spaghetticodingclub.domain.user.dto.UpdateUserPasswordRequestDTO;
 import wercsmik.spaghetticodingclub.domain.user.entity.User;
+import wercsmik.spaghetticodingclub.domain.user.entity.UserRoleEnum;
 import wercsmik.spaghetticodingclub.domain.user.repository.UserRepository;
 import wercsmik.spaghetticodingclub.global.exception.CustomException;
 import wercsmik.spaghetticodingclub.global.exception.ErrorCode;
@@ -74,6 +76,18 @@ public class UserService {
         }
 
         userRepository.save(user);
+    }
+
+    @Transactional
+    public void updateUserName(Long userId, UpdateUserNameRequestDTO requestDTO, User loginUser) {
+        User userToUpdate = getUser(userId);
+
+        if (loginUser.getRole() == UserRoleEnum.USER && !loginUser.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.AUTHENTICATION_MISMATCH_EXCEPTION);
+        }
+
+        userToUpdate.setUsername(requestDTO.getUsername());
+        userRepository.save(userToUpdate);
     }
 
     public User getUser(Long userId) {


### PR DESCRIPTION
## 요구사항
- 사용자(Admin, User)는 본인의 이름을 변경 할 수 있어야 합니다.
- Admin 사용자는 User 사용자의 이름을 변경 할 수 있어야 합니다.
- User 사용자는 본인 외에 다른 사용자들의 이름을 변경 할 수 없어야 합니다.

## 구현 항목
- [x] Controller / API 로직 구현
- [x] Service / 권한, 본인여부 에 따라 기능이 작동하도록 로직 추가
- [x] Entity / setUsername 메서드 추가
- [x] UpdateUserNameRequestDTO 추가.

## 기대 효과
- 사용자들은 본인의 이름을 변경 할 수 있습니다.
- 회원가입 한 User 사용자들의 이름이 동일한경우 Admin 사용자는 User 사용자들을 구분하기 위하여 임의적으로 이름을 수정하여 구분 할 수 있습니다.

#### 테스트 :
- 포스트맨(Postman)을 사용하여 API 엔드포인트에 대한 통합 테스트를 수행하였습니다.