### PR TITLE
feature/Auth 본인 이메일 인증링크 발송 기능, 추천인 이메일 인증링크 발송 기능, 이메일 검증 3개 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
 
     // AWS Parameter Store
     implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.1.0")
@@ -38,14 +36,16 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // DB
-    implementation 'org.springframework.boot:spring-boot-starter'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     // JWT
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 dependencyManagement {

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/controller/AuthController.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/controller/AuthController.java
@@ -5,13 +5,18 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import wercsmik.spaghetticodingclub.domain.auth.dto.DeleteRequestDTO;
+import wercsmik.spaghetticodingclub.domain.auth.dto.EmailCheckRequestDTO;
 import wercsmik.spaghetticodingclub.domain.auth.dto.SignRequestDTO;
 import wercsmik.spaghetticodingclub.domain.auth.service.AuthService;
+import wercsmik.spaghetticodingclub.domain.auth.service.EmailService;
+import wercsmik.spaghetticodingclub.domain.user.repository.UserRepository;
 import wercsmik.spaghetticodingclub.global.common.CommonResponse;
 import wercsmik.spaghetticodingclub.global.security.UserDetailsImpl;
 
@@ -20,9 +25,14 @@ import wercsmik.spaghetticodingclub.global.security.UserDetailsImpl;
 public class AuthController {
 
     private final AuthService authService;
+    private final EmailService emailService;
+    private final UserRepository userRepository;
 
-    public AuthController(AuthService authService) {
+    public AuthController(AuthService authService, EmailService emailService,
+            UserRepository userRepository) {
         this.authService = authService;
+        this.emailService = emailService;
+        this.userRepository = userRepository;
     }
 
     @PostMapping("/signup")
@@ -32,7 +42,46 @@ public class AuthController {
         authService.signup(signRequestDTO);
 
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(CommonResponse.of("회원가입 성공", null));
+                .body(CommonResponse.of("회원가입이 완료되었습니다.", null));
+    }
+
+    @PostMapping("/send-user-verification-link")
+    public ResponseEntity<CommonResponse<Void>> sendUserVerificationLink(
+            @Valid @RequestBody EmailCheckRequestDTO request) {
+
+        emailService.sendVerificationLink(request.getEmail(), "USER_EMAIL", null);
+        String message = String.format("%s 메일로 인증 링크 발송 성공", request.getEmail());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.of(message, null));
+    }
+
+    @PostMapping("/send-recommend-verification-link")
+    public ResponseEntity<CommonResponse<Void>> sendRecommendVerificationLink(
+            @Valid @RequestBody EmailCheckRequestDTO request) {
+        if (!emailService.isEmailVerified(request.getEmail())) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(CommonResponse.of("본인 메일 인증 후 다시 시도 바랍니다.", null));
+        }
+
+        emailService.sendVerificationLink(request.getRecommendEmail(), "RECOMMEND_EMAIL", request.getEmail());
+        String message = String.format("%s 메일로 인증 링크 발송 성공", request.getRecommendEmail());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.of(message, null));
+    }
+
+    @GetMapping("/verify-email")
+    public ResponseEntity<CommonResponse<Void>> verifyEmail(
+            @RequestParam("token") String token) {
+
+        System.out.println("Email verification request received for token: " + token);
+        boolean isVerified = authService.verifyEmail(token);
+        if (isVerified) {
+            return ResponseEntity.status(HttpStatus.OK)
+                    .body(CommonResponse.of("이메일 인증 성공. 다시 회원가입 버튼을 눌러주세요.", null));
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(CommonResponse.of("인증 토큰이 유효하지 않습니다", null));
+        }
     }
 
     @DeleteMapping("/withDraw")

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/dto/EmailCheckRequestDTO.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/dto/EmailCheckRequestDTO.java
@@ -1,0 +1,20 @@
+package wercsmik.spaghetticodingclub.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(force = true)
+@AllArgsConstructor
+public class EmailCheckRequestDTO {
+
+    @Email(message = "옳지 않은 메일 주소입니다. 다시 입력해주세요")
+    private String email;
+
+    @Email(message = "옳지 않은 메일 주소입니다. 다시 입력해주세요")
+    private String recommendEmail;
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/entity/EmailVerification.java
@@ -1,4 +1,51 @@
 package wercsmik.spaghetticodingclub.domain.auth.entity;
 
-public class EmailVerification {
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import wercsmik.spaghetticodingclub.global.auditing.BaseTimeEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailVerification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long verificationId;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String token;
+
+    @Column(nullable = false)
+    private boolean isVerified = false;
+
+    @Column(nullable = false)
+    private LocalDateTime expirationDate;  // 유효 시간 추가
+
+    @Column(nullable = false)
+    private String emailType;  // 이메일 유형 추가 (USER_EMAIL, RECOMMEND_EMAIL)
+
+    @Builder
+    public EmailVerification(String email, String token, boolean isVerified, LocalDateTime expirationDate, String emailType) {
+        this.email = email;
+        this.token = token;
+        this.isVerified = isVerified;
+        this.expirationDate = expirationDate;
+        this.emailType = emailType;
+    }
+
+    public void setVerified(boolean isVerified) {
+        this.isVerified = isVerified;
+    }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/repository/EmailVerificationRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/repository/EmailVerificationRepository.java
@@ -1,4 +1,4 @@
-package wercsmik.spaghetticodingclub.domain.auth.repotiroy;
+package wercsmik.spaghetticodingclub.domain.auth.repository;
 
 import java.time.LocalDateTime;
 import java.util.Optional;

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/repotiroy/EmailVerificationRepository.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/repotiroy/EmailVerificationRepository.java
@@ -1,4 +1,23 @@
 package wercsmik.spaghetticodingclub.domain.auth.repotiroy;
 
-public interface EmailVerificationRepository {
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import wercsmik.spaghetticodingclub.domain.auth.entity.EmailVerification;
+
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+
+    Optional<EmailVerification> findByToken(String token);
+
+    Optional<EmailVerification> findByEmail(String email);
+
+    Optional<EmailVerification> findByEmailAndIsVerifiedTrue(String email);
+
+    Optional<EmailVerification> findByEmailAndIsVerifiedTrueAndEmailType(String email, String emailType);
+
+    void deleteByEmailAndEmailType(String email, String emailType);
+
+    void deleteByEmail(String email);
+
+    void deleteByExpirationDateBefore(LocalDateTime now);  // 만료된 인증 정보를 삭제하는 메서드
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/AuthService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/AuthService.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import wercsmik.spaghetticodingclub.domain.auth.dto.DeleteRequestDTO;
 import wercsmik.spaghetticodingclub.domain.auth.dto.SignRequestDTO;
 import wercsmik.spaghetticodingclub.domain.auth.entity.EmailVerification;
-import wercsmik.spaghetticodingclub.domain.auth.repotiroy.EmailVerificationRepository;
+import wercsmik.spaghetticodingclub.domain.auth.repository.EmailVerificationRepository;
 import wercsmik.spaghetticodingclub.domain.track.repository.TrackRepository;
 import wercsmik.spaghetticodingclub.domain.track.service.TrackParticipantsService;
 import wercsmik.spaghetticodingclub.domain.user.entity.User;

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/AuthService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/AuthService.java
@@ -1,12 +1,17 @@
 package wercsmik.spaghetticodingclub.domain.auth.service;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wercsmik.spaghetticodingclub.domain.auth.dto.DeleteRequestDTO;
 import wercsmik.spaghetticodingclub.domain.auth.dto.SignRequestDTO;
+import wercsmik.spaghetticodingclub.domain.auth.entity.EmailVerification;
+import wercsmik.spaghetticodingclub.domain.auth.repotiroy.EmailVerificationRepository;
 import wercsmik.spaghetticodingclub.domain.track.repository.TrackRepository;
 import wercsmik.spaghetticodingclub.domain.track.service.TrackParticipantsService;
 import wercsmik.spaghetticodingclub.domain.user.entity.User;
@@ -18,15 +23,18 @@ import wercsmik.spaghetticodingclub.global.security.UserDetailsImpl;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AuthService {
 
     private final UserRepository userRepository;
     private final TrackRepository trackRepository;
     private final PasswordEncoder passwordEncoder;
     private final TrackParticipantsService trackParticipantsService;
+    private final EmailService emailService;
+    private final EmailVerificationRepository emailVerificationRepository;
 
+    @Transactional
     public void signup(SignRequestDTO signRequestDTO) {
-
         String username = signRequestDTO.getUsername();
         String email = signRequestDTO.getEmail();
         String password = signRequestDTO.getPassword();
@@ -34,44 +42,101 @@ public class AuthService {
         String trackName = signRequestDTO.getTrack();
         String recommendEmail = signRequestDTO.getRecommendEmail();
 
-        // 이메일 중복확인
-        if (userRepository.findByEmail(signRequestDTO.getEmail()).isPresent()) {
+        if (userRepository.findByEmail(email).isPresent()) {
+            log.warn("Email already exists: {}", email);
             throw new CustomException(ErrorCode.EMAIL_ALREADY_EXIST);
         }
 
-        // 비밀번호 != 비밀번호 확인
         if (!Objects.equals(password, checkPassword)) {
+            log.warn("Passwords do not match for: {}", email);
             throw new CustomException(ErrorCode.PASSWORD_CONFIRMATION_NOT_MATCH);
         }
 
-        String encodePassword = passwordEncoder.encode(password);
-
-        UserRoleEnum role = UserRoleEnum.USER; // 기본적으로 USER로 설정
-        // recommendEmail 값이 null이 아니고 빈 문자열이 아닐 경우에만 ADMIN 설정
+        UserRoleEnum role = UserRoleEnum.USER;
         if (recommendEmail != null && !recommendEmail.trim().isEmpty()) {
             role = UserRoleEnum.ADMIN;
         }
 
-        // USER로 가입하고 트랙이 지정되어 있을 경우, 트랙 존재 여부 먼저 확인
-        if (role == UserRoleEnum.USER && trackName != null && !trackName.trim().isEmpty()) {
+        if (role == UserRoleEnum.USER && (trackName == null || trackName.trim().isEmpty())) {
+            log.warn("Track is required for: {}", email);
+            throw new CustomException(ErrorCode.TRACK_REQUIRED);
+        }
+
+        if (role == UserRoleEnum.USER) {
             trackRepository.findByTrackName(trackName)
-                    .orElseThrow(() -> new CustomException(ErrorCode.TRACK_NOT_FOUND));
-            // 여기서 예외가 발생하면, 아래의 유저 저장 로직은 실행되지 않음
+                    .orElseThrow(() -> {
+                        log.warn("Track not found: {}", trackName);
+                        return new CustomException(ErrorCode.TRACK_NOT_FOUND);
+                    });
+        }
+
+        // 이메일 인증 여부 확인
+        if (role == UserRoleEnum.ADMIN) {
+            boolean isUserEmailVerified = emailVerificationRepository.findByEmailAndIsVerifiedTrueAndEmailType(email, "USER_EMAIL").isPresent();
+            boolean isRecommendEmailVerified = emailVerificationRepository.findByEmailAndIsVerifiedTrueAndEmailType(recommendEmail, "RECOMMEND_EMAIL").isPresent();
+
+            if (!isUserEmailVerified || !isRecommendEmailVerified) {
+                log.warn("Email verification incomplete for: {}", email);
+                throw new CustomException(ErrorCode.EMAIL_NOT_VERIFIED);
+            }
+        } else {
+            EmailVerification emailVerification = emailVerificationRepository.findByEmailAndIsVerifiedTrue(email)
+                    .orElseThrow(() -> {
+                        log.warn("Email not verified: {}", email);
+                        return new CustomException(ErrorCode.EMAIL_NOT_VERIFIED);
+                    });
+
+            if (emailVerification.getExpirationDate().isBefore(LocalDateTime.now())) {
+                log.warn("Verification token expired for: {}", email);
+                throw new CustomException(ErrorCode.INVALID_VERIFICATION_TOKEN);
+            }
         }
 
         User user = User.builder()
                 .username(username)
-                .password(encodePassword)
+                .password(passwordEncoder.encode(password))
                 .email(email)
                 .recommendEmail(recommendEmail)
                 .role(role)
+                .isVerified(true)
                 .build();
+
         userRepository.save(user);
 
-        // recommendEmail이 없어서 USER로 가입한 경우에만 트랙참여자에 추가
-        if (role == UserRoleEnum.USER) {
+        if (role == UserRoleEnum.USER && trackName != null) {
             trackParticipantsService.addParticipant(user.getUserId(), trackName);
         }
+
+        if (role == UserRoleEnum.ADMIN) {
+            emailVerificationRepository.deleteByEmailAndEmailType(email, "USER_EMAIL"); // 인증 후 삭제
+            emailVerificationRepository.deleteByEmailAndEmailType(recommendEmail, "RECOMMEND_EMAIL"); // 인증 후 삭제
+        } else {
+            emailVerificationRepository.deleteByEmail(email); // 인증 후 삭제
+        }
+    }
+
+    @Transactional
+    public boolean verifyEmail(String token) {
+        System.out.println("Verifying email with token: " + token);
+        Optional<EmailVerification> verificationOpt = emailVerificationRepository.findByToken(token);
+        if (verificationOpt.isPresent()) {
+            EmailVerification emailVerification = verificationOpt.get();
+            if (emailVerification.getExpirationDate().isBefore(LocalDateTime.now())) {
+                throw new CustomException(ErrorCode.INVALID_VERIFICATION_TOKEN);
+            }
+            emailVerification.setVerified(true);
+            emailVerificationRepository.save(emailVerification);
+            return true;
+        } else {
+            throw new CustomException(ErrorCode.INVALID_VERIFICATION_TOKEN);
+        }
+    }
+
+    public boolean isEmailVerified(String email) {
+        Optional<EmailVerification> emailVerificationOpt = emailVerificationRepository.findByEmailAndIsVerifiedTrue(email);
+        boolean isVerified = emailVerificationOpt.isPresent();
+
+        return isVerified;
     }
 
     @Transactional

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/EmailService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/EmailService.java
@@ -1,0 +1,88 @@
+package wercsmik.spaghetticodingclub.domain.auth.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import wercsmik.spaghetticodingclub.domain.auth.entity.EmailVerification;
+import wercsmik.spaghetticodingclub.domain.auth.repotiroy.EmailVerificationRepository;
+import wercsmik.spaghetticodingclub.global.exception.CustomException;
+import wercsmik.spaghetticodingclub.global.exception.ErrorCode;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+    private final EmailVerificationRepository emailVerificationRepository;
+
+    @Transactional
+    public void sendVerificationLink(String email, String emailType, String requesterEmail) {
+        // 이메일 인증 상태 확인
+        if (emailVerificationRepository.findByEmailAndIsVerifiedTrueAndEmailType(email, emailType).isPresent()) {
+            log.warn("Email already verified: {}", email);
+            throw new CustomException(ErrorCode.EMAIL_ALREADY_VERIFIED);
+        }
+
+        // 기존의 인증 기록 삭제
+        emailVerificationRepository.deleteByEmailAndEmailType(email, emailType);
+
+        // 인증 토큰 생성
+        String token = UUID.randomUUID().toString();
+        String verificationLink = "http://localhost:8080/api/auths/verify-email?token=" + token;
+
+        // HTML 이메일 생성
+        String messageContent = createMessageContent(emailType, requesterEmail, verificationLink);
+
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            helper.setFrom(System.getenv("EMAIL_USERNAME"));
+            helper.setTo(email);
+            helper.setSubject("이메일 인증 링크");
+            helper.setText(messageContent, true); // true indicates the content is HTML
+
+            mailSender.send(message);
+
+            // 인증 토큰 저장
+            EmailVerification emailVerification = EmailVerification.builder()
+                    .email(email)
+                    .token(token)
+                    .isVerified(false)
+                    .expirationDate(LocalDateTime.now().plusMinutes(30))  // 유효 시간 설정
+                    .emailType(emailType)
+                    .build();
+            emailVerificationRepository.save(emailVerification);
+            log.info("Verification link sent to: {}", email);
+        } catch (MessagingException e) {
+            log.error("Failed to send email to: {}", email, e);
+            throw new RuntimeException("Failed to send email", e);
+        }
+    }
+
+    private String createMessageContent(String emailType, String requesterEmail, String verificationLink) {
+        if ("RECOMMEND_EMAIL".equals(emailType)) {
+            return String.format("<p>%s 님께서 인증 요청을 위해서 링크를 보내드립니다.</p>"
+                            + "<p>새로 가입하려는 관리자가 맞을 경우 아래 버튼을 클릭하세요:</p>"
+                            + "<a href=\"%s\" style=\"display:inline-block;padding:10px 20px;font-size:16px;color:white;background-color:#4CAF50;text-decoration:none;border-radius:5px;\">인증하기</a>",
+                    requesterEmail, verificationLink);
+        } else {
+            return String.format("<p>이메일 인증을 위해 아래 버튼을 클릭하세요:</p>"
+                            + "<a href=\"%s\" style=\"display:inline-block;padding:10px 20px;font-size:16px;color:white;background-color:#4CAF50;text-decoration:none;border-radius:5px;\">인증하기</a>",
+                    verificationLink);
+        }
+    }
+
+    public boolean isEmailVerified(String email) {
+        Optional<EmailVerification> verificationOpt = emailVerificationRepository.findByEmailAndIsVerifiedTrue(email);
+        return verificationOpt.isPresent();
+    }
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/EmailService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/EmailService.java
@@ -12,7 +12,7 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wercsmik.spaghetticodingclub.domain.auth.entity.EmailVerification;
-import wercsmik.spaghetticodingclub.domain.auth.repotiroy.EmailVerificationRepository;
+import wercsmik.spaghetticodingclub.domain.auth.repository.EmailVerificationRepository;
 import wercsmik.spaghetticodingclub.global.exception.CustomException;
 import wercsmik.spaghetticodingclub.global.exception.ErrorCode;
 

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/EmailVerificationCleanupService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/EmailVerificationCleanupService.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import wercsmik.spaghetticodingclub.domain.auth.repotiroy.EmailVerificationRepository;
+import wercsmik.spaghetticodingclub.domain.auth.repository.EmailVerificationRepository;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/EmailVerificationCleanupService.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/auth/service/EmailVerificationCleanupService.java
@@ -1,0 +1,24 @@
+package wercsmik.spaghetticodingclub.domain.auth.service;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import wercsmik.spaghetticodingclub.domain.auth.repotiroy.EmailVerificationRepository;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationCleanupService {
+
+    private final EmailVerificationRepository emailVerificationRepository;
+
+    @Scheduled(fixedRate = 3600000)  // 1시간마다 실행
+    public void cleanupExpiredVerifications() {
+
+        LocalDateTime now = LocalDateTime.now();
+        emailVerificationRepository.deleteByExpirationDateBefore(now);
+
+        System.out.println("Expired email verifications cleaned up at: " + now);
+    }
+
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/domain/user/entity/User.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/domain/user/entity/User.java
@@ -1,6 +1,20 @@
 package wercsmik.spaghetticodingclub.domain.user.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,9 +23,6 @@ import wercsmik.spaghetticodingclub.domain.assessment.entity.Assessment;
 import wercsmik.spaghetticodingclub.domain.team.entity.Team;
 import wercsmik.spaghetticodingclub.domain.team.entity.TeamMember;
 import wercsmik.spaghetticodingclub.global.auditing.BaseTimeEntity;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -39,6 +50,9 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private UserRoleEnum role;
 
+    @Column(nullable = false)
+    private boolean isVerified; // 추가: 사용자 인증 상태
+
     @OneToMany(mappedBy = "userId", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Assessment> receivedAssessments = new ArrayList<>();
 
@@ -53,12 +67,13 @@ public class User extends BaseTimeEntity {
     private Team team;
 
     @Builder
-    private User(String username, String password, String email, String recommendEmail, UserRoleEnum role) {
+    private User(String username, String password, String email, String recommendEmail, UserRoleEnum role, boolean isVerified) {
         this.username = username;
         this.password = password;
         this.email = email;
         this.recommendEmail = recommendEmail;
         this.role = role;
+        this.isVerified = isVerified;
     }
 
     public void setPassword(String updatePassword) {
@@ -71,5 +86,9 @@ public class User extends BaseTimeEntity {
 
     public void setUsername(String username) {
         this.username = username;
+    }
+
+    public void setVerified(boolean verified) {
+        isVerified = verified;
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/global/config/EmailConfig.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/config/EmailConfig.java
@@ -1,0 +1,31 @@
+package wercsmik.spaghetticodingclub.global.config;
+
+import java.util.Properties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class EmailConfig {
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(587);
+
+        // 환경 변수에서 이메일 계정 정보 가져오기
+        mailSender.setUsername(System.getenv("EMAIL_USERNAME"));
+        mailSender.setPassword(System.getenv("EMAIL_PASSWORD"));
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.debug", "true");
+        props.put("mail.smtp.from", System.getenv("EMAIL_USERNAME"));
+
+        return mailSender;
+    }
+}

--- a/src/main/java/wercsmik/spaghetticodingclub/global/config/WebSecurityConfig.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/config/WebSecurityConfig.java
@@ -1,6 +1,8 @@
 package wercsmik.spaghetticodingclub.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -22,9 +24,6 @@ import wercsmik.spaghetticodingclub.global.jwt.JwtAuthenticationFilter;
 import wercsmik.spaghetticodingclub.global.jwt.JwtAuthorizationFilter;
 import wercsmik.spaghetticodingclub.global.jwt.JwtUtil;
 import wercsmik.spaghetticodingclub.global.security.UserDetailsServiceImpl;
-
-import java.util.Arrays;
-import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -98,7 +97,8 @@ public class WebSecurityConfig {
                         .requestMatchers("/api/auths/login").permitAll() // '/api/auths/login' 접근 허가
                         .requestMatchers("/api/auths/withDraw").authenticated() // '/api/auths/withDraw' 요청은 인증 필요
                         .requestMatchers("/api/auths/verify-email").permitAll() // 이메일 인증 요청 허가
-                        .requestMatchers("/api/auths/send-verification-code").permitAll() // 인증 코드 발송 요청 허가
+                        .requestMatchers("/api/auths/send-user-verification-link").permitAll() // 인증 링크 발송 요청 허가
+                        .requestMatchers("/api/auths/send-recommend-verification-link").permitAll() // 인증 링크 발송 요청 허가
                         .requestMatchers("/tracks").permitAll() // '/tracks' 요청 접근 허가 (트랙 전체 조회)
                         .requestMatchers("/schedules/**").authenticated() // '/schedules/'로 시작하는 요청은 인증 필요
                         .requestMatchers("/spaghettiiii").permitAll() // aws 테스트를 위함

--- a/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/exception/ErrorCode.java
@@ -28,6 +28,14 @@ public enum ErrorCode {
 
     EMAIL_VERIFICATION_CODE_INVALID(400, "입력하신 이메일 인증 코드가 유효하지 않습니다"),
 
+    INVALID_VERIFICATION_TOKEN(400, "토큰이 유효하지 않습니다"),
+
+    TRACK_REQUIRED(400,"트랙이 필요합니다." ),
+
+    EMAIL_NOT_VERIFIED(400, "이메일 인증이 필요합니다."),
+
+    EMAIL_ALREADY_VERIFIED(400, "인증이 확인된 메일주소 입니다."),
+
     // Scheduler
     SCHEDULE_OVERLAP(400, "일정이 겹칩니다."),
 
@@ -48,6 +56,7 @@ public enum ErrorCode {
     TRACK_NAME_DUPLICATED(400, "이미 존재하는 트랙입니다."),
 
     INVALID_TRACK_NAME(400, "잘못된 트랙 이름입니다."),
+
 
 
     // Track Notice

--- a/src/main/java/wercsmik/spaghetticodingclub/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/exception/GlobalExceptionHandler.java
@@ -3,7 +3,9 @@ package wercsmik.spaghetticodingclub.global.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
@@ -19,5 +21,16 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = ErrorResponse.of(customException.getMessage());
 
         return ResponseEntity.status(httpStatus).body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<ErrorResponse> handleValidationExceptions(
+            MethodArgumentNotValidException ex) {
+
+        String errorMessage = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        ErrorResponse errorResponse = ErrorResponse.of(errorMessage);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 }

--- a/src/main/java/wercsmik/spaghetticodingclub/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/wercsmik/spaghetticodingclub/global/jwt/JwtAuthenticationFilter.java
@@ -72,6 +72,15 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         String email = user.getEmail();
         UserRoleEnum role = user.getRole();
 
+        // 인증 여부 확인
+        if (!user.isVerified()) {
+            // 사용자가 인증되지 않은 경우
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            CommonResponse commonResponse = CommonResponse.of("인증이 필요합니다", null);
+            writeResponse(response, commonResponse);
+            return;
+        }
+
         String accessToken = jwtUtil.createAccessToken(email, role);
 
         jwtUtil.addJwtToHeader(accessToken, response);

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,6 +13,27 @@ spring:
         show_sql: true
     open-in-view: false
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${EMAIL_USERNAME}
+    password: ${EMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          ssl:
+            enable: false
+
+  task:
+    scheduling:
+      pool:
+        size: 5
+      thread-name-prefix: scheduler-
+
 jwt:
   secret:
     key: ${jwt.secretKey}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,6 +17,27 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
     show-sql: true
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${EMAIL_USERNAME}
+    password: ${EMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          ssl:
+            enable: false
+
+  task:
+    scheduling:
+      pool:
+        size: 5
+      thread-name-prefix: scheduler-
+
 jwt:
   secret:
     key: ${jwt.secretKey}


### PR DESCRIPTION
### 설명
이 PR은 '본인 이메일 인증을위한 인증링크발송, 추천인 이메일 인증을 위한 인증링크 발송, 이메일 인증 확인' 총 3개의 기능을 구현한 내용이며 회원가입시 수강생은 본인인증을 통한 가입, 관리자는 본인인증과 추천인인증을 통하여 무분별한 회원가입을 막기위한 내용입니다.

### 주요 변경 사항
수강생의 경우 본인 이메일 인증이 확인된다면 회원가입이 가능하지만 관리자의 경우 본인 이메일을 인증이 확인된 상태여야만 '추천인 이메일 인증링크 발송'기능을 통해서 추천인 관리자의 이메일로 인증링크를 보내 인증후 새로운 관리자로 가입이 가능합니다.
발송 이메일은 토큰 값으로 DB에 저장되며 회원가입이 완료될경우 관련된 토큰값이 삭제되거나, 재발송 요청시 이전 토큰값을 삭제후 발송처리하며, 유효시간이 지난 토큰값은 스케줄러에 의하여 일정시간마다 DB를 정리함으로서 DB성능의 저하를 막을 수 있습니다. 

### 기대 효과
수강생의 경우 본인 인증, 관리자의 경우 본인 인증, 추천인 인증을 통하여 무분별한 사용자의 회원가입을 막을 수 있습니다.